### PR TITLE
Improve Gradle build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,7 @@ nbdist/
 .nb-gradle/
 
 # End of https://www.gitignore.io/api/git,java,maven,eclipse,netbeans,jetbrains+all
+
+# Minecraft server jar and obfuscation maps
+1.*-mappings.txt
+1.*-server*.jar


### PR DESCRIPTION
This PR changes the build script to use the `maven-publish` plugin when installing the server jar.
I've added a check for existing files in the `DownloadFileTask`.
I also fixed it so that the actions in `installServerJar` only run during the task.