### PR TITLE
Add an excluding regex to the StateRemapper annotation 

### DIFF
--- a/src/main/java/org/geysermc/generator/MappingsGenerator.java
+++ b/src/main/java/org/geysermc/generator/MappingsGenerator.java
@@ -444,10 +444,10 @@ public class MappingsGenerator {
                         }
                     }
                 }
-                String[] antiBlockRegex = stateMapper.getClass().getAnnotation(StateRemapper.class).excludingBlockRegex();
-                if (antiBlockRegex.length != 0) {
-                    for (String excludeRegex : antiBlockRegex) {
-                        if (trimmedIdentifier.matches(excludeRegex)) {
+                String[] excludingBlockRegex = stateMapper.getClass().getAnnotation(StateRemapper.class).excludingBlockRegex();
+                if (excludingBlockRegex.length != 0) {
+                    for (String regex : excludingBlockRegex) {
+                        if (trimmedIdentifier.matches(regex)) {
                             continue stateLoop;
                         }
                     }

--- a/src/main/java/org/geysermc/generator/MappingsGenerator.java
+++ b/src/main/java/org/geysermc/generator/MappingsGenerator.java
@@ -444,6 +444,15 @@ public class MappingsGenerator {
                         }
                     }
                 }
+                String[] antiBlockRegex = stateMapper.getClass().getAnnotation(StateRemapper.class).excludingBlockRegex();
+                if (antiBlockRegex.length != 0) {
+                    for (String excludeRegex : antiBlockRegex) {
+                        if (trimmedIdentifier.matches(excludeRegex)) {
+                            continue stateLoop;
+                        }
+                    }
+                }
+
                 String value = javaState.split("=")[1];
                 Pair<String, ?> bedrockState = stateMapper.translateState(identifier, value);
                 if (bedrockState.getValue() instanceof Number) {

--- a/src/main/java/org/geysermc/generator/state/StateRemapper.java
+++ b/src/main/java/org/geysermc/generator/state/StateRemapper.java
@@ -15,6 +15,13 @@ public @interface StateRemapper {
     String[] blockRegex() default "";
 
     /**
+     * Regex string to exclude blocks when remapping states for blocks. Leave empty to exclude no blocks.
+     *
+     * @return regex string to exclude blocks when remapping states for blocks
+     */
+    String[] excludingBlockRegex() default "";
+
+    /**
      * The name of the Minecraft: Java Edition blockstate data.
      *
      * @return the name of the Minecraft: java edition blockstate data.


### PR DESCRIPTION
This might help out in the future with new blocks that match existing regex, by avoiding making the inclusive regex uglier and more confusing. 