### PR TITLE
Map candles to sea_pickles and candle_cake to cake

### DIFF
--- a/src/main/java/org/geysermc/generator/Main.java
+++ b/src/main/java/org/geysermc/generator/Main.java
@@ -1,10 +1,7 @@
 package org.geysermc.generator;
 
 import net.minecraft.SharedConstants;
-
-import net.minecraft.core.Registry;
 import net.minecraft.server.Bootstrap;
-import net.minecraft.world.level.gameevent.PositionSourceType;
 
 import java.io.PrintStream;
 
@@ -24,5 +21,7 @@ public class Main {
         generator.generateItems();
         generator.generateBlocks();
         generator.generateSounds();
+
+        // todo: don't map candles to sea_pickles and candle_cakes to cakes once bedrock gets them
     }
 }

--- a/src/main/java/org/geysermc/generator/state/type/CandleCountMapper.java
+++ b/src/main/java/org/geysermc/generator/state/type/CandleCountMapper.java
@@ -10,7 +10,7 @@ public class CandleCountMapper extends StateMapper<Integer> {
 
     @Override
     public Pair<String, Integer> translateState(String fullIdentifier, String value) {
-        // todo: don't map candles to pickles and cake candles to cake once Bedrock gets candles
+        // map candles to pickles until bedrock gets them
         int additionalPickles = Integer.parseInt(value) - 1;
         return Pair.of("cluster_count", additionalPickles);
     }

--- a/src/main/java/org/geysermc/generator/state/type/CandleCountMapper.java
+++ b/src/main/java/org/geysermc/generator/state/type/CandleCountMapper.java
@@ -1,0 +1,17 @@
+package org.geysermc.generator.state.type;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.geysermc.generator.state.StateMapper;
+import org.geysermc.generator.state.StateRemapper;
+
+@StateRemapper(value = "candles", blockRegex = ".*candle$")
+public class CandleCountMapper extends StateMapper<Integer> {
+
+
+    @Override
+    public Pair<String, Integer> translateState(String fullIdentifier, String value) {
+        // todo: don't map candles to pickles and cake candles to cake once Bedrock gets candles
+        int additionalPickles = Integer.parseInt(value) - 1;
+        return Pair.of("cluster_count", additionalPickles);
+    }
+}

--- a/src/main/java/org/geysermc/generator/state/type/CandleWaterloggedMapper.java
+++ b/src/main/java/org/geysermc/generator/state/type/CandleWaterloggedMapper.java
@@ -1,0 +1,15 @@
+package org.geysermc.generator.state.type;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.geysermc.generator.state.StateMapper;
+import org.geysermc.generator.state.StateRemapper;
+
+@StateRemapper(value = "waterlogged", blockRegex = ".*candle$")
+public class CandleWaterloggedMapper extends StateMapper<Boolean> {
+
+    @Override
+    public Pair<String, Boolean> translateState(String fullIdentifier, String value) {
+        // sea pickles dead_bit is true if there is no water
+        return Pair.of("dead_bit", !value.equals("true"));
+    }
+}


### PR DESCRIPTION
StateMappers for:

- mapped all candles to sea pickles, with correct waterlog/quantity
- mapped cake candles to full cakes

The mappings changes should only be an update to `af2d3a85b04517ba76e72d48eef5bb3b837ec5bb` of `feature/1.17`

removed some unused imports and added some todo's for the future