### PR TITLE
Add bedrock item palette diff calculation

### DIFF
--- a/palettes/README.md
+++ b/palettes/README.md
@@ -14,3 +14,7 @@ The required palette is included in this repository, however if you would like t
 After running ProxyPass and connecting to it from Minecraft Bedrock the palettes should be dumped to the data folder. 
 
 Currently, mappings-generator only uses `runtime_item_states.json`; copy that file to this directory.
+
+A difference file (`bedrock_item_diff.txt`) can be generated to show items that have been added, removed, or had their numerical IDs changed. 
+`old_runtime_item_states.json` must be provided in this directory, which should be a `runtime_item_states.json` of an older game version.  
+**Warning**: Although Bedrock Edition and Java Edition may both have an identical item name, there are many that are actually different items.

--- a/palettes/bedrock_item_diff.txt
+++ b/palettes/bedrock_item_diff.txt
@@ -1,0 +1,378 @@
+Bedrock item names that have been removed and are in Java:
+Bedrock item names that have been removed and are not in Java:
+Bedrock item names that are new and are in Java:
+++ minecraft:deepslate_tiles : -387
+++ minecraft:deepslate_tile_stairs : -389
+++ minecraft:exposed_cut_copper_slab : -362
+++ minecraft:waxed_oxidized_cut_copper_stairs : -448
+++ minecraft:deepslate_copper_ore : -408
+++ minecraft:tuff : -333
+++ minecraft:waxed_oxidized_copper : -446
+++ minecraft:calcite : -326
+++ minecraft:exposed_cut_copper : -348
+++ minecraft:glow_ink_sac : 503
+++ minecraft:glow_lichen : -411
+++ minecraft:waxed_oxidized_cut_copper_slab : -449
+++ minecraft:waxed_oxidized_cut_copper : -447
+++ minecraft:pointed_dripstone : -308
+++ minecraft:amethyst_shard : 623
+++ minecraft:large_amethyst_bud : -330
+++ minecraft:weathered_cut_copper_stairs : -356
+++ minecraft:waxed_exposed_cut_copper_stairs : -359
+++ minecraft:powder_snow_bucket : 368
+++ minecraft:moss_block : -320
+++ minecraft:raw_gold : 506
+++ minecraft:cut_copper : -347
+++ minecraft:waxed_weathered_copper : -346
+++ minecraft:oxidized_cut_copper_slab : -364
+++ minecraft:azalea : -337
+++ minecraft:lightning_rod : -312
+++ minecraft:polished_deepslate_wall : -386
+++ minecraft:waxed_exposed_cut_copper_slab : -366
+++ minecraft:waxed_weathered_cut_copper_slab : -367
+++ minecraft:infested_deepslate : -454
+++ minecraft:raw_copper : 507
+++ minecraft:weathered_cut_copper_slab : -363
+++ minecraft:sculk_sensor : -307
+++ minecraft:glow_squid_spawn_egg : 502
+++ minecraft:cracked_deepslate_tiles : -409
+++ minecraft:tinted_glass : -334
+++ minecraft:polished_deepslate : -383
+++ minecraft:goat_spawn_egg : 501
+++ minecraft:deepslate_iron_ore : -401
+++ minecraft:polished_deepslate_stairs : -385
+++ minecraft:glow_berries : 630
+++ minecraft:exposed_cut_copper_stairs : -355
+++ minecraft:waxed_cut_copper_stairs : -358
+++ minecraft:moss_carpet : -335
+++ minecraft:cobbled_deepslate_stairs : -381
+++ minecraft:chiseled_deepslate : -395
+++ minecraft:hanging_roots : -319
+++ minecraft:polished_deepslate_slab : -384
+++ minecraft:amethyst_block : -327
+++ minecraft:big_dripleaf : -323
+++ minecraft:waxed_weathered_cut_copper : -353
+++ minecraft:oxidized_cut_copper_stairs : -357
+++ minecraft:deepslate_emerald_ore : -407
+++ minecraft:small_amethyst_bud : -332
+++ minecraft:deepslate_brick_slab : -392
+++ minecraft:smooth_basalt : -377
+++ minecraft:cut_copper_stairs : -354
+++ minecraft:copper_block : -340
+++ minecraft:weathered_copper : -342
+++ minecraft:exposed_copper : -341
+++ minecraft:waxed_exposed_cut_copper : -352
+++ minecraft:cobbled_deepslate_wall : -382
+++ minecraft:flowering_azalea : -338
+++ minecraft:weathered_cut_copper : -349
+++ minecraft:copper_ingot : 504
+++ minecraft:deepslate_redstone_ore : -403
+++ minecraft:azalea_leaves : -324
+++ minecraft:cracked_deepslate_bricks : -410
+++ minecraft:deepslate_lapis_ore : -400
+++ minecraft:raw_iron_block : -451
+++ minecraft:deepslate_brick_wall : -394
+++ minecraft:dripstone_block : -317
+++ minecraft:raw_gold_block : -453
+++ minecraft:waxed_cut_copper : -351
+++ minecraft:axolotl_spawn_egg : 500
+++ minecraft:spore_blossom : -321
+++ minecraft:budding_amethyst : -328
+++ minecraft:oxidized_copper : -343
+++ minecraft:deepslate_diamond_ore : -405
+++ minecraft:deepslate_brick_stairs : -393
+++ minecraft:deepslate_coal_ore : -406
+++ minecraft:amethyst_cluster : -329
+++ minecraft:waxed_weathered_cut_copper_stairs : -360
+++ minecraft:deepslate_tile_slab : -388
+++ minecraft:raw_iron : 505
+++ minecraft:spyglass : 624
+++ minecraft:cobbled_deepslate : -379
+++ minecraft:waxed_cut_copper_slab : -365
+++ minecraft:cut_copper_slab : -361
+++ minecraft:deepslate_gold_ore : -402
+++ minecraft:deepslate_tile_wall : -390
+++ minecraft:waxed_exposed_copper : -345
+++ minecraft:deepslate_bricks : -391
+++ minecraft:oxidized_cut_copper : -350
+++ minecraft:raw_copper_block : -452
+++ minecraft:medium_amethyst_bud : -331
+++ minecraft:axolotl_bucket : 369
+++ minecraft:deepslate : -378
+++ minecraft:copper_ore : -311
+++ minecraft:cobbled_deepslate_slab : -380
+Bedrock item names that are new and are not in Java:
+++ minecraft:waxed_oxidized_double_cut_copper_slab : -450
+++ minecraft:dirt_with_roots : -318
+++ minecraft:item.glow_frame : -339
+++ minecraft:lit_deepslate_redstone_ore : -404
+++ minecraft:goat_horn : 622
+++ minecraft:cave_vines : -322
+++ minecraft:powder_snow : -306
+++ minecraft:exposed_double_cut_copper_slab : -369
+++ minecraft:azalea_leaves_flowered : -325
+++ minecraft:waxed_double_cut_copper_slab : -372
+++ minecraft:weathered_double_cut_copper_slab : -370
+++ minecraft:polished_deepslate_double_slab : -397
+++ minecraft:waxed_copper : -344
+++ minecraft:waxed_exposed_double_cut_copper_slab : -373
+++ minecraft:glow_frame : 621
+++ minecraft:oxidized_double_cut_copper_slab : -371
+++ minecraft:deepslate_tile_double_slab : -398
+++ minecraft:double_cut_copper_slab : -368
+++ minecraft:cobbled_deepslate_double_slab : -396
+++ minecraft:deepslate_brick_double_slab : -399
+++ minecraft:cave_vines_head_with_berries : -376
+++ minecraft:waxed_weathered_double_cut_copper_slab : -374
+++ minecraft:small_dripleaf_block : -336
+++ minecraft:cave_vines_body_with_berries : -375
+Bedrock item names that have had their IDs changed, and are in Java:
+|| minecraft:ghast_spawn_egg : 452 --> 454
+|| minecraft:name_tag : 538 --> 548
+|| minecraft:flower_banner_pattern : 571 --> 581
+|| minecraft:golden_horse_armor : 522 --> 532
+|| minecraft:saddle : 369 --> 371
+|| minecraft:zoglin_spawn_egg : 496 --> 498
+|| minecraft:blue_dye : 397 --> 399
+|| minecraft:skull_banner_pattern : 573 --> 583
+|| minecraft:endermite_spawn_egg : 458 --> 460
+|| minecraft:polar_bear_spawn_egg : 470 --> 472
+|| minecraft:firework_star : 510 --> 520
+|| minecraft:quartz : 514 --> 524
+|| minecraft:written_book : 501 --> 511
+|| minecraft:honey_bottle : 581 --> 591
+|| minecraft:white_dye : 408 --> 410
+|| minecraft:netherite_hoe : 596 --> 606
+|| minecraft:cyan_dye : 399 --> 401
+|| minecraft:crimson_sign : 602 --> 612
+|| minecraft:iron_horse_armor : 521 --> 531
+|| minecraft:chest_minecart : 387 --> 389
+|| minecraft:light_blue_dye : 405 --> 407
+|| minecraft:netherite_boots : 600 --> 610
+|| minecraft:lime_dye : 403 --> 405
+|| minecraft:zombie_villager_spawn_egg : 475 --> 477
+|| minecraft:stray_spawn_egg : 460 --> 462
+|| minecraft:armor_stand : 542 --> 552
+|| minecraft:green_dye : 395 --> 397
+|| minecraft:evoker_spawn_egg : 473 --> 475
+|| minecraft:music_disc_pigstep : 608 --> 618
+|| minecraft:wither_skeleton_spawn_egg : 462 --> 464
+|| minecraft:jungle_boat : 375 --> 377
+|| minecraft:black_dye : 393 --> 395
+|| minecraft:trident : 536 --> 546
+|| minecraft:prismarine_shard : 555 --> 565
+|| minecraft:magma_cube_spawn_egg : 453 --> 455
+|| minecraft:scute : 562 --> 572
+|| minecraft:dark_oak_door : 547 --> 557
+|| minecraft:nautilus_shell : 560 --> 570
+|| minecraft:tropical_fish_spawn_egg : 477 --> 479
+|| minecraft:minecart : 368 --> 370
+|| minecraft:clay_ball : 382 --> 384
+|| minecraft:sugar : 414 --> 416
+|| minecraft:music_disc_strad : 532 --> 542
+|| minecraft:vex_spawn_egg : 474 --> 476
+|| minecraft:wandering_trader_spawn_egg : 490 --> 492
+|| minecraft:hopper_minecart : 516 --> 526
+|| minecraft:glistering_melon_slice : 432 --> 434
+|| minecraft:brown_dye : 396 --> 398
+|| minecraft:tnt_minecart : 515 --> 525
+|| minecraft:leather_horse_armor : 520 --> 530
+|| minecraft:acacia_door : 546 --> 556
+|| minecraft:flower_pot : 504 --> 514
+|| minecraft:panda_spawn_egg : 487 --> 489
+|| minecraft:spruce_sign : 566 --> 576
+|| minecraft:egg : 388 --> 390
+|| minecraft:splash_potion : 551 --> 561
+|| minecraft:silverfish_spawn_egg : 441 --> 443
+|| minecraft:enchanted_book : 511 --> 521
+|| minecraft:honeycomb : 580 --> 590
+|| minecraft:music_disc_11 : 534 --> 544
+|| minecraft:music_disc_13 : 524 --> 534
+|| minecraft:leather : 379 --> 381
+|| minecraft:kelp : 380 --> 382
+|| minecraft:music_disc_stal : 531 --> 541
+|| minecraft:end_crystal : 615 --> 629
+|| minecraft:experience_bottle : 498 --> 508
+|| minecraft:comparator : 512 --> 522
+|| minecraft:ender_eye : 431 --> 433
+|| minecraft:heart_of_the_sea : 561 --> 571
+|| minecraft:ocelot_spawn_egg : 449 --> 451
+|| minecraft:birch_sign : 567 --> 577
+|| minecraft:music_disc_mall : 529 --> 539
+|| minecraft:campfire : 578 --> 588
+|| minecraft:elytra : 554 --> 564
+|| minecraft:skeleton_spawn_egg : 442 --> 444
+|| minecraft:iron_door : 370 --> 372
+|| minecraft:villager_spawn_egg : 447 --> 449
+|| minecraft:mutton : 540 --> 550
+|| minecraft:firework_rocket : 509 --> 519
+|| minecraft:crimson_door : 604 --> 614
+|| minecraft:shulker_shell : 556 --> 566
+|| minecraft:elder_guardian_spawn_egg : 469 --> 471
+|| minecraft:acacia_boat : 377 --> 379
+|| minecraft:emerald : 502 --> 512
+|| minecraft:nether_star : 508 --> 518
+|| minecraft:oak_boat : 373 --> 375
+|| minecraft:slime_ball : 386 --> 388
+|| minecraft:phantom_spawn_egg : 484 --> 486
+|| minecraft:hoglin_spawn_egg : 494 --> 496
+|| minecraft:brick : 381 --> 383
+|| minecraft:dark_oak_boat : 378 --> 380
+|| minecraft:potion : 424 --> 426
+|| minecraft:husk_spawn_egg : 461 --> 463
+|| minecraft:music_disc_blocks : 526 --> 536
+|| minecraft:blaze_spawn_egg : 454 --> 456
+|| minecraft:book : 385 --> 387
+|| minecraft:mule_spawn_egg : 464 --> 466
+|| minecraft:bone : 413 --> 415
+|| minecraft:creeper_banner_pattern : 572 --> 582
+|| minecraft:jungle_door : 545 --> 555
+|| minecraft:diamond_horse_armor : 523 --> 533
+|| minecraft:zombie_horse_spawn_egg : 466 --> 468
+|| minecraft:spruce_door : 543 --> 553
+|| minecraft:bee_spawn_egg : 492 --> 494
+|| minecraft:cod_spawn_egg : 478 --> 480
+|| minecraft:writable_book : 500 --> 510
+|| minecraft:snowball : 372 --> 374
+|| minecraft:llama_spawn_egg : 471 --> 473
+|| minecraft:fox_spawn_egg : 488 --> 490
+|| minecraft:piglin_brute_spawn_egg : 497 --> 499
+|| minecraft:soul_campfire : 610 --> 620
+|| minecraft:pig_spawn_egg : 435 --> 437
+|| minecraft:compass : 389 --> 391
+|| minecraft:cow_spawn_egg : 434 --> 436
+|| minecraft:cake : 415 --> 417
+|| minecraft:birch_door : 544 --> 554
+|| minecraft:filled_map : 418 --> 420
+|| minecraft:ghast_tear : 422 --> 424
+|| minecraft:squid_spawn_egg : 448 --> 450
+|| minecraft:cooked_mutton : 541 --> 551
+|| minecraft:blaze_powder : 427 --> 429
+|| minecraft:magenta_dye : 406 --> 408
+|| minecraft:netherite_leggings : 599 --> 609
+|| minecraft:magma_cream : 428 --> 430
+|| minecraft:red_dye : 394 --> 396
+|| minecraft:witch_spawn_egg : 450 --> 452
+|| minecraft:popped_chorus_fruit : 549 --> 559
+|| minecraft:ink_sac : 411 --> 413
+|| minecraft:orange_dye : 407 --> 409
+|| minecraft:pillager_spawn_egg : 489 --> 491
+|| minecraft:prismarine_crystals : 539 --> 549
+|| minecraft:cave_spider_spawn_egg : 455 --> 457
+|| minecraft:bone_meal : 409 --> 411
+|| minecraft:brewing_stand : 429 --> 431
+|| minecraft:chain : 607 --> 617
+|| minecraft:bat_spawn_egg : 451 --> 453
+|| minecraft:spruce_boat : 376 --> 378
+|| minecraft:paper : 384 --> 386
+|| minecraft:spider_spawn_egg : 444 --> 446
+|| minecraft:piglin_banner_pattern : 577 --> 587
+|| minecraft:rabbit_spawn_egg : 457 --> 459
+|| minecraft:fire_charge : 499 --> 509
+|| minecraft:music_disc_cat : 525 --> 535
+|| minecraft:cauldron : 430 --> 432
+|| minecraft:jungle_sign : 568 --> 578
+|| minecraft:warped_sign : 603 --> 613
+|| minecraft:blaze_rod : 421 --> 423
+|| minecraft:mojang_banner_pattern : 574 --> 584
+|| minecraft:piglin_spawn_egg : 495 --> 497
+|| minecraft:netherite_shovel : 593 --> 603
+|| minecraft:netherite_scrap : 601 --> 611
+|| minecraft:turtle_spawn_egg : 483 --> 485
+|| minecraft:mooshroom_spawn_egg : 438 --> 440
+|| minecraft:phantom_membrane : 564 --> 574
+|| minecraft:fermented_spider_eye : 426 --> 428
+|| minecraft:repeater : 417 --> 419
+|| minecraft:music_disc_mellohi : 530 --> 540
+|| minecraft:pufferfish_spawn_egg : 479 --> 481
+|| minecraft:parrot_spawn_egg : 476 --> 478
+|| minecraft:zombie_spawn_egg : 445 --> 447
+|| minecraft:music_disc_chirp : 527 --> 537
+|| minecraft:redstone : 371 --> 373
+|| minecraft:wolf_spawn_egg : 437 --> 439
+|| minecraft:shears : 419 --> 421
+|| minecraft:rabbit_hide : 519 --> 529
+|| minecraft:gray_dye : 401 --> 403
+|| minecraft:cocoa_beans : 410 --> 412
+|| minecraft:iron_nugget : 559 --> 569
+|| minecraft:skeleton_horse_spawn_egg : 465 --> 467
+|| minecraft:suspicious_stew : 579 --> 589
+|| minecraft:sheep_spawn_egg : 436 --> 438
+|| minecraft:music_disc_ward : 533 --> 543
+|| minecraft:carrot_on_a_stick : 507 --> 517
+|| minecraft:netherite_pickaxe : 594 --> 604
+|| minecraft:netherite_ingot : 591 --> 601
+|| minecraft:slime_spawn_egg : 443 --> 445
+|| minecraft:vindicator_spawn_egg : 472 --> 474
+|| minecraft:dragon_breath : 550 --> 560
+|| minecraft:netherite_helmet : 597 --> 607
+|| minecraft:drowned_spawn_egg : 481 --> 483
+|| minecraft:glass_bottle : 425 --> 427
+|| minecraft:dolphin_spawn_egg : 482 --> 484
+|| minecraft:ender_pearl : 420 --> 422
+|| minecraft:music_disc_far : 528 --> 538
+|| minecraft:donkey_spawn_egg : 463 --> 465
+|| minecraft:rabbit_foot : 518 --> 528
+|| minecraft:purple_dye : 398 --> 400
+|| minecraft:gold_nugget : 423 --> 425
+|| minecraft:birch_boat : 374 --> 376
+|| minecraft:nether_sprouts : 609 --> 619
+|| minecraft:enderman_spawn_egg : 440 --> 442
+|| minecraft:lead : 537 --> 547
+|| minecraft:chicken_spawn_egg : 433 --> 435
+|| minecraft:shulker_spawn_egg : 467 --> 469
+|| minecraft:strider_spawn_egg : 493 --> 495
+|| minecraft:netherite_chestplate : 598 --> 608
+|| minecraft:hopper : 517 --> 527
+|| minecraft:dark_oak_sign : 570 --> 580
+|| minecraft:warped_fungus_on_a_stick : 606 --> 616
+|| minecraft:glowstone_dust : 392 --> 394
+|| minecraft:yellow_dye : 404 --> 406
+|| minecraft:music_disc_wait : 535 --> 545
+|| minecraft:cat_spawn_egg : 486 --> 488
+|| minecraft:fishing_rod : 390 --> 392
+|| minecraft:guardian_spawn_egg : 459 --> 461
+|| minecraft:pink_dye : 402 --> 404
+|| minecraft:totem_of_undying : 558 --> 568
+|| minecraft:netherite_axe : 595 --> 605
+|| minecraft:salmon_spawn_egg : 480 --> 482
+|| minecraft:creeper_spawn_egg : 439 --> 441
+|| minecraft:turtle_helmet : 563 --> 573
+|| minecraft:crossbow : 565 --> 575
+|| minecraft:acacia_sign : 569 --> 579
+|| minecraft:warped_door : 605 --> 615
+|| minecraft:chorus_fruit : 548 --> 558
+|| minecraft:horse_spawn_egg : 456 --> 458
+|| minecraft:clock : 391 --> 393
+|| minecraft:lapis_lazuli : 412 --> 414
+|| minecraft:lingering_potion : 552 --> 562
+|| minecraft:ravager_spawn_egg : 491 --> 493
+|| minecraft:command_block_minecart : 553 --> 563
+|| minecraft:sugar_cane : 383 --> 385
+|| minecraft:light_gray_dye : 400 --> 402
+|| minecraft:netherite_sword : 592 --> 602
+Bedrock item names have had their IDs changed, and are not in Java:
+|| minecraft:balloon : 587 --> 597
+|| minecraft:empty_map : 505 --> 515
+|| minecraft:field_masoned_banner_pattern : 575 --> 585
+|| minecraft:compound : 583 --> 593
+|| minecraft:banner_pattern : 613 --> 627
+|| minecraft:medicine : 588 --> 598
+|| minecraft:frame : 503 --> 513
+|| minecraft:skull : 506 --> 516
+|| minecraft:bordure_indented_banner_pattern : 576 --> 586
+|| minecraft:spawn_egg : 614 --> 628
+|| minecraft:netherbrick : 513 --> 523
+|| minecraft:npc_spawn_egg : 468 --> 470
+|| minecraft:bed : 416 --> 418
+|| minecraft:ice_bomb : 584 --> 594
+|| minecraft:bleach : 585 --> 595
+|| minecraft:boat : 611 --> 625
+|| minecraft:lodestone_compass : 590 --> 600
+|| minecraft:sparkler : 589 --> 599
+|| minecraft:camera : 582 --> 592
+|| minecraft:dye : 612 --> 626
+|| minecraft:zombie_pigman_spawn_egg : 446 --> 448
+|| minecraft:banner : 557 --> 567
+|| minecraft:rapid_fertilizer : 586 --> 596
+|| minecraft:agent_spawn_egg : 485 --> 487

--- a/palettes/old_runtime_item_states.json
+++ b/palettes/old_runtime_item_states.json
@@ -1,0 +1,3658 @@
+[
+  {
+    "name" : "minecraft:acacia_boat",
+    "id" : 377
+  },
+  {
+    "name" : "minecraft:acacia_button",
+    "id" : -140
+  },
+  {
+    "name" : "minecraft:acacia_door",
+    "id" : 546
+  },
+  {
+    "name" : "minecraft:acacia_fence_gate",
+    "id" : 187
+  },
+  {
+    "name" : "minecraft:acacia_pressure_plate",
+    "id" : -150
+  },
+  {
+    "name" : "minecraft:acacia_sign",
+    "id" : 569
+  },
+  {
+    "name" : "minecraft:acacia_stairs",
+    "id" : 163
+  },
+  {
+    "name" : "minecraft:acacia_standing_sign",
+    "id" : -190
+  },
+  {
+    "name" : "minecraft:acacia_trapdoor",
+    "id" : -145
+  },
+  {
+    "name" : "minecraft:acacia_wall_sign",
+    "id" : -191
+  },
+  {
+    "name" : "minecraft:activator_rail",
+    "id" : 126
+  },
+  {
+    "name" : "minecraft:agent_spawn_egg",
+    "id" : 485
+  },
+  {
+    "name" : "minecraft:air",
+    "id" : -158
+  },
+  {
+    "name" : "minecraft:allow",
+    "id" : 210
+  },
+  {
+    "name" : "minecraft:ancient_debris",
+    "id" : -271
+  },
+  {
+    "name" : "minecraft:andesite_stairs",
+    "id" : -171
+  },
+  {
+    "name" : "minecraft:anvil",
+    "id" : 145
+  },
+  {
+    "name" : "minecraft:apple",
+    "id" : 257
+  },
+  {
+    "name" : "minecraft:armor_stand",
+    "id" : 542
+  },
+  {
+    "name" : "minecraft:arrow",
+    "id" : 301
+  },
+  {
+    "name" : "minecraft:baked_potato",
+    "id" : 281
+  },
+  {
+    "name" : "minecraft:balloon",
+    "id" : 587
+  },
+  {
+    "name" : "minecraft:bamboo",
+    "id" : -163
+  },
+  {
+    "name" : "minecraft:bamboo_sapling",
+    "id" : -164
+  },
+  {
+    "name" : "minecraft:banner",
+    "id" : 557
+  },
+  {
+    "name" : "minecraft:banner_pattern",
+    "id" : 613
+  },
+  {
+    "name" : "minecraft:barrel",
+    "id" : -203
+  },
+  {
+    "name" : "minecraft:barrier",
+    "id" : -161
+  },
+  {
+    "name" : "minecraft:basalt",
+    "id" : -234
+  },
+  {
+    "name" : "minecraft:bat_spawn_egg",
+    "id" : 451
+  },
+  {
+    "name" : "minecraft:beacon",
+    "id" : 138
+  },
+  {
+    "name" : "minecraft:bed",
+    "id" : 416
+  },
+  {
+    "name" : "minecraft:bedrock",
+    "id" : 7
+  },
+  {
+    "name" : "minecraft:bee_nest",
+    "id" : -218
+  },
+  {
+    "name" : "minecraft:bee_spawn_egg",
+    "id" : 492
+  },
+  {
+    "name" : "minecraft:beef",
+    "id" : 273
+  },
+  {
+    "name" : "minecraft:beehive",
+    "id" : -219
+  },
+  {
+    "name" : "minecraft:beetroot",
+    "id" : 285
+  },
+  {
+    "name" : "minecraft:beetroot_seeds",
+    "id" : 295
+  },
+  {
+    "name" : "minecraft:beetroot_soup",
+    "id" : 286
+  },
+  {
+    "name" : "minecraft:bell",
+    "id" : -206
+  },
+  {
+    "name" : "minecraft:birch_boat",
+    "id" : 374
+  },
+  {
+    "name" : "minecraft:birch_button",
+    "id" : -141
+  },
+  {
+    "name" : "minecraft:birch_door",
+    "id" : 544
+  },
+  {
+    "name" : "minecraft:birch_fence_gate",
+    "id" : 184
+  },
+  {
+    "name" : "minecraft:birch_pressure_plate",
+    "id" : -151
+  },
+  {
+    "name" : "minecraft:birch_sign",
+    "id" : 567
+  },
+  {
+    "name" : "minecraft:birch_stairs",
+    "id" : 135
+  },
+  {
+    "name" : "minecraft:birch_standing_sign",
+    "id" : -186
+  },
+  {
+    "name" : "minecraft:birch_trapdoor",
+    "id" : -146
+  },
+  {
+    "name" : "minecraft:birch_wall_sign",
+    "id" : -187
+  },
+  {
+    "name" : "minecraft:black_dye",
+    "id" : 393
+  },
+  {
+    "name" : "minecraft:black_glazed_terracotta",
+    "id" : 235
+  },
+  {
+    "name" : "minecraft:blackstone",
+    "id" : -273
+  },
+  {
+    "name" : "minecraft:blackstone_double_slab",
+    "id" : -283
+  },
+  {
+    "name" : "minecraft:blackstone_slab",
+    "id" : -282
+  },
+  {
+    "name" : "minecraft:blackstone_stairs",
+    "id" : -276
+  },
+  {
+    "name" : "minecraft:blackstone_wall",
+    "id" : -277
+  },
+  {
+    "name" : "minecraft:blast_furnace",
+    "id" : -196
+  },
+  {
+    "name" : "minecraft:blaze_powder",
+    "id" : 427
+  },
+  {
+    "name" : "minecraft:blaze_rod",
+    "id" : 421
+  },
+  {
+    "name" : "minecraft:blaze_spawn_egg",
+    "id" : 454
+  },
+  {
+    "name" : "minecraft:bleach",
+    "id" : 585
+  },
+  {
+    "name" : "minecraft:blue_dye",
+    "id" : 397
+  },
+  {
+    "name" : "minecraft:blue_glazed_terracotta",
+    "id" : 231
+  },
+  {
+    "name" : "minecraft:blue_ice",
+    "id" : -11
+  },
+  {
+    "name" : "minecraft:boat",
+    "id" : 611
+  },
+  {
+    "name" : "minecraft:bone",
+    "id" : 413
+  },
+  {
+    "name" : "minecraft:bone_block",
+    "id" : 216
+  },
+  {
+    "name" : "minecraft:bone_meal",
+    "id" : 409
+  },
+  {
+    "name" : "minecraft:book",
+    "id" : 385
+  },
+  {
+    "name" : "minecraft:bookshelf",
+    "id" : 47
+  },
+  {
+    "name" : "minecraft:border_block",
+    "id" : 212
+  },
+  {
+    "name" : "minecraft:bordure_indented_banner_pattern",
+    "id" : 576
+  },
+  {
+    "name" : "minecraft:bow",
+    "id" : 300
+  },
+  {
+    "name" : "minecraft:bowl",
+    "id" : 321
+  },
+  {
+    "name" : "minecraft:bread",
+    "id" : 261
+  },
+  {
+    "name" : "minecraft:brewing_stand",
+    "id" : 429
+  },
+  {
+    "name" : "minecraft:brewingstandblock",
+    "id" : 117
+  },
+  {
+    "name" : "minecraft:brick",
+    "id" : 381
+  },
+  {
+    "name" : "minecraft:brick_block",
+    "id" : 45
+  },
+  {
+    "name" : "minecraft:brick_stairs",
+    "id" : 108
+  },
+  {
+    "name" : "minecraft:brown_dye",
+    "id" : 396
+  },
+  {
+    "name" : "minecraft:brown_glazed_terracotta",
+    "id" : 232
+  },
+  {
+    "name" : "minecraft:brown_mushroom",
+    "id" : 39
+  },
+  {
+    "name" : "minecraft:brown_mushroom_block",
+    "id" : 99
+  },
+  {
+    "name" : "minecraft:bubble_column",
+    "id" : -160
+  },
+  {
+    "name" : "minecraft:bucket",
+    "id" : 360
+  },
+  {
+    "name" : "minecraft:cactus",
+    "id" : 81
+  },
+  {
+    "name" : "minecraft:cake",
+    "id" : 415
+  },
+  {
+    "name" : "minecraft:camera",
+    "id" : 582
+  },
+  {
+    "name" : "minecraft:campfire",
+    "id" : 578
+  },
+  {
+    "name" : "minecraft:carpet",
+    "id" : 171
+  },
+  {
+    "name" : "minecraft:carrot",
+    "id" : 279
+  },
+  {
+    "name" : "minecraft:carrot_on_a_stick",
+    "id" : 507
+  },
+  {
+    "name" : "minecraft:carrots",
+    "id" : 141
+  },
+  {
+    "name" : "minecraft:cartography_table",
+    "id" : -200
+  },
+  {
+    "name" : "minecraft:carved_pumpkin",
+    "id" : -155
+  },
+  {
+    "name" : "minecraft:cat_spawn_egg",
+    "id" : 486
+  },
+  {
+    "name" : "minecraft:cauldron",
+    "id" : 430
+  },
+  {
+    "name" : "minecraft:cave_spider_spawn_egg",
+    "id" : 455
+  },
+  {
+    "name" : "minecraft:chain",
+    "id" : 607
+  },
+  {
+    "name" : "minecraft:chain_command_block",
+    "id" : 189
+  },
+  {
+    "name" : "minecraft:chainmail_boots",
+    "id" : 342
+  },
+  {
+    "name" : "minecraft:chainmail_chestplate",
+    "id" : 340
+  },
+  {
+    "name" : "minecraft:chainmail_helmet",
+    "id" : 339
+  },
+  {
+    "name" : "minecraft:chainmail_leggings",
+    "id" : 341
+  },
+  {
+    "name" : "minecraft:charcoal",
+    "id" : 303
+  },
+  {
+    "name" : "minecraft:chemical_heat",
+    "id" : 192
+  },
+  {
+    "name" : "minecraft:chemistry_table",
+    "id" : 238
+  },
+  {
+    "name" : "minecraft:chest",
+    "id" : 54
+  },
+  {
+    "name" : "minecraft:chest_minecart",
+    "id" : 387
+  },
+  {
+    "name" : "minecraft:chicken",
+    "id" : 275
+  },
+  {
+    "name" : "minecraft:chicken_spawn_egg",
+    "id" : 433
+  },
+  {
+    "name" : "minecraft:chiseled_nether_bricks",
+    "id" : -302
+  },
+  {
+    "name" : "minecraft:chiseled_polished_blackstone",
+    "id" : -279
+  },
+  {
+    "name" : "minecraft:chorus_flower",
+    "id" : 200
+  },
+  {
+    "name" : "minecraft:chorus_fruit",
+    "id" : 548
+  },
+  {
+    "name" : "minecraft:chorus_plant",
+    "id" : 240
+  },
+  {
+    "name" : "minecraft:clay",
+    "id" : 82
+  },
+  {
+    "name" : "minecraft:clay_ball",
+    "id" : 382
+  },
+  {
+    "name" : "minecraft:clock",
+    "id" : 391
+  },
+  {
+    "name" : "minecraft:coal",
+    "id" : 302
+  },
+  {
+    "name" : "minecraft:coal_block",
+    "id" : 173
+  },
+  {
+    "name" : "minecraft:coal_ore",
+    "id" : 16
+  },
+  {
+    "name" : "minecraft:cobblestone",
+    "id" : 4
+  },
+  {
+    "name" : "minecraft:cobblestone_wall",
+    "id" : 139
+  },
+  {
+    "name" : "minecraft:cocoa",
+    "id" : 127
+  },
+  {
+    "name" : "minecraft:cocoa_beans",
+    "id" : 410
+  },
+  {
+    "name" : "minecraft:cod",
+    "id" : 264
+  },
+  {
+    "name" : "minecraft:cod_bucket",
+    "id" : 364
+  },
+  {
+    "name" : "minecraft:cod_spawn_egg",
+    "id" : 478
+  },
+  {
+    "name" : "minecraft:colored_torch_bp",
+    "id" : 204
+  },
+  {
+    "name" : "minecraft:colored_torch_rg",
+    "id" : 202
+  },
+  {
+    "name" : "minecraft:command_block",
+    "id" : 137
+  },
+  {
+    "name" : "minecraft:command_block_minecart",
+    "id" : 553
+  },
+  {
+    "name" : "minecraft:comparator",
+    "id" : 512
+  },
+  {
+    "name" : "minecraft:compass",
+    "id" : 389
+  },
+  {
+    "name" : "minecraft:composter",
+    "id" : -213
+  },
+  {
+    "name" : "minecraft:compound",
+    "id" : 583
+  },
+  {
+    "name" : "minecraft:concrete",
+    "id" : 236
+  },
+  {
+    "name" : "minecraft:concrete_powder",
+    "id" : 237
+  },
+  {
+    "name" : "minecraft:conduit",
+    "id" : -157
+  },
+  {
+    "name" : "minecraft:cooked_beef",
+    "id" : 274
+  },
+  {
+    "name" : "minecraft:cooked_chicken",
+    "id" : 276
+  },
+  {
+    "name" : "minecraft:cooked_cod",
+    "id" : 268
+  },
+  {
+    "name" : "minecraft:cooked_mutton",
+    "id" : 541
+  },
+  {
+    "name" : "minecraft:cooked_porkchop",
+    "id" : 263
+  },
+  {
+    "name" : "minecraft:cooked_rabbit",
+    "id" : 289
+  },
+  {
+    "name" : "minecraft:cooked_salmon",
+    "id" : 269
+  },
+  {
+    "name" : "minecraft:cookie",
+    "id" : 271
+  },
+  {
+    "name" : "minecraft:coral",
+    "id" : -131
+  },
+  {
+    "name" : "minecraft:coral_block",
+    "id" : -132
+  },
+  {
+    "name" : "minecraft:coral_fan",
+    "id" : -133
+  },
+  {
+    "name" : "minecraft:coral_fan_dead",
+    "id" : -134
+  },
+  {
+    "name" : "minecraft:coral_fan_hang",
+    "id" : -135
+  },
+  {
+    "name" : "minecraft:coral_fan_hang2",
+    "id" : -136
+  },
+  {
+    "name" : "minecraft:coral_fan_hang3",
+    "id" : -137
+  },
+  {
+    "name" : "minecraft:cow_spawn_egg",
+    "id" : 434
+  },
+  {
+    "name" : "minecraft:cracked_nether_bricks",
+    "id" : -303
+  },
+  {
+    "name" : "minecraft:cracked_polished_blackstone_bricks",
+    "id" : -280
+  },
+  {
+    "name" : "minecraft:crafting_table",
+    "id" : 58
+  },
+  {
+    "name" : "minecraft:creeper_banner_pattern",
+    "id" : 572
+  },
+  {
+    "name" : "minecraft:creeper_spawn_egg",
+    "id" : 439
+  },
+  {
+    "name" : "minecraft:crimson_button",
+    "id" : -260
+  },
+  {
+    "name" : "minecraft:crimson_door",
+    "id" : 604
+  },
+  {
+    "name" : "minecraft:crimson_double_slab",
+    "id" : -266
+  },
+  {
+    "name" : "minecraft:crimson_fence",
+    "id" : -256
+  },
+  {
+    "name" : "minecraft:crimson_fence_gate",
+    "id" : -258
+  },
+  {
+    "name" : "minecraft:crimson_fungus",
+    "id" : -228
+  },
+  {
+    "name" : "minecraft:crimson_hyphae",
+    "id" : -299
+  },
+  {
+    "name" : "minecraft:crimson_nylium",
+    "id" : -232
+  },
+  {
+    "name" : "minecraft:crimson_planks",
+    "id" : -242
+  },
+  {
+    "name" : "minecraft:crimson_pressure_plate",
+    "id" : -262
+  },
+  {
+    "name" : "minecraft:crimson_roots",
+    "id" : -223
+  },
+  {
+    "name" : "minecraft:crimson_sign",
+    "id" : 602
+  },
+  {
+    "name" : "minecraft:crimson_slab",
+    "id" : -264
+  },
+  {
+    "name" : "minecraft:crimson_stairs",
+    "id" : -254
+  },
+  {
+    "name" : "minecraft:crimson_standing_sign",
+    "id" : -250
+  },
+  {
+    "name" : "minecraft:crimson_stem",
+    "id" : -225
+  },
+  {
+    "name" : "minecraft:crimson_trapdoor",
+    "id" : -246
+  },
+  {
+    "name" : "minecraft:crimson_wall_sign",
+    "id" : -252
+  },
+  {
+    "name" : "minecraft:crossbow",
+    "id" : 565
+  },
+  {
+    "name" : "minecraft:crying_obsidian",
+    "id" : -289
+  },
+  {
+    "name" : "minecraft:cyan_dye",
+    "id" : 399
+  },
+  {
+    "name" : "minecraft:cyan_glazed_terracotta",
+    "id" : 229
+  },
+  {
+    "name" : "minecraft:dark_oak_boat",
+    "id" : 378
+  },
+  {
+    "name" : "minecraft:dark_oak_button",
+    "id" : -142
+  },
+  {
+    "name" : "minecraft:dark_oak_door",
+    "id" : 547
+  },
+  {
+    "name" : "minecraft:dark_oak_fence_gate",
+    "id" : 186
+  },
+  {
+    "name" : "minecraft:dark_oak_pressure_plate",
+    "id" : -152
+  },
+  {
+    "name" : "minecraft:dark_oak_sign",
+    "id" : 570
+  },
+  {
+    "name" : "minecraft:dark_oak_stairs",
+    "id" : 164
+  },
+  {
+    "name" : "minecraft:dark_oak_trapdoor",
+    "id" : -147
+  },
+  {
+    "name" : "minecraft:dark_prismarine_stairs",
+    "id" : -3
+  },
+  {
+    "name" : "minecraft:darkoak_standing_sign",
+    "id" : -192
+  },
+  {
+    "name" : "minecraft:darkoak_wall_sign",
+    "id" : -193
+  },
+  {
+    "name" : "minecraft:daylight_detector",
+    "id" : 151
+  },
+  {
+    "name" : "minecraft:daylight_detector_inverted",
+    "id" : 178
+  },
+  {
+    "name" : "minecraft:deadbush",
+    "id" : 32
+  },
+  {
+    "name" : "minecraft:deny",
+    "id" : 211
+  },
+  {
+    "name" : "minecraft:detector_rail",
+    "id" : 28
+  },
+  {
+    "name" : "minecraft:diamond",
+    "id" : 304
+  },
+  {
+    "name" : "minecraft:diamond_axe",
+    "id" : 319
+  },
+  {
+    "name" : "minecraft:diamond_block",
+    "id" : 57
+  },
+  {
+    "name" : "minecraft:diamond_boots",
+    "id" : 350
+  },
+  {
+    "name" : "minecraft:diamond_chestplate",
+    "id" : 348
+  },
+  {
+    "name" : "minecraft:diamond_helmet",
+    "id" : 347
+  },
+  {
+    "name" : "minecraft:diamond_hoe",
+    "id" : 332
+  },
+  {
+    "name" : "minecraft:diamond_horse_armor",
+    "id" : 523
+  },
+  {
+    "name" : "minecraft:diamond_leggings",
+    "id" : 349
+  },
+  {
+    "name" : "minecraft:diamond_ore",
+    "id" : 56
+  },
+  {
+    "name" : "minecraft:diamond_pickaxe",
+    "id" : 318
+  },
+  {
+    "name" : "minecraft:diamond_shovel",
+    "id" : 317
+  },
+  {
+    "name" : "minecraft:diamond_sword",
+    "id" : 316
+  },
+  {
+    "name" : "minecraft:diorite_stairs",
+    "id" : -170
+  },
+  {
+    "name" : "minecraft:dirt",
+    "id" : 3
+  },
+  {
+    "name" : "minecraft:dispenser",
+    "id" : 23
+  },
+  {
+    "name" : "minecraft:dolphin_spawn_egg",
+    "id" : 482
+  },
+  {
+    "name" : "minecraft:donkey_spawn_egg",
+    "id" : 463
+  },
+  {
+    "name" : "minecraft:double_plant",
+    "id" : 175
+  },
+  {
+    "name" : "minecraft:double_stone_slab",
+    "id" : 44
+  },
+  {
+    "name" : "minecraft:double_stone_slab2",
+    "id" : 182
+  },
+  {
+    "name" : "minecraft:double_stone_slab3",
+    "id" : -162
+  },
+  {
+    "name" : "minecraft:double_stone_slab4",
+    "id" : -166
+  },
+  {
+    "name" : "minecraft:double_wooden_slab",
+    "id" : 157
+  },
+  {
+    "name" : "minecraft:dragon_breath",
+    "id" : 550
+  },
+  {
+    "name" : "minecraft:dragon_egg",
+    "id" : 122
+  },
+  {
+    "name" : "minecraft:dried_kelp",
+    "id" : 270
+  },
+  {
+    "name" : "minecraft:dried_kelp_block",
+    "id" : -139
+  },
+  {
+    "name" : "minecraft:dropper",
+    "id" : 125
+  },
+  {
+    "name" : "minecraft:drowned_spawn_egg",
+    "id" : 481
+  },
+  {
+    "name" : "minecraft:dye",
+    "id" : 612
+  },
+  {
+    "name" : "minecraft:egg",
+    "id" : 388
+  },
+  {
+    "name" : "minecraft:elder_guardian_spawn_egg",
+    "id" : 469
+  },
+  {
+    "name" : "minecraft:element_0",
+    "id" : 36
+  },
+  {
+    "name" : "minecraft:element_1",
+    "id" : -12
+  },
+  {
+    "name" : "minecraft:element_10",
+    "id" : -21
+  },
+  {
+    "name" : "minecraft:element_100",
+    "id" : -111
+  },
+  {
+    "name" : "minecraft:element_101",
+    "id" : -112
+  },
+  {
+    "name" : "minecraft:element_102",
+    "id" : -113
+  },
+  {
+    "name" : "minecraft:element_103",
+    "id" : -114
+  },
+  {
+    "name" : "minecraft:element_104",
+    "id" : -115
+  },
+  {
+    "name" : "minecraft:element_105",
+    "id" : -116
+  },
+  {
+    "name" : "minecraft:element_106",
+    "id" : -117
+  },
+  {
+    "name" : "minecraft:element_107",
+    "id" : -118
+  },
+  {
+    "name" : "minecraft:element_108",
+    "id" : -119
+  },
+  {
+    "name" : "minecraft:element_109",
+    "id" : -120
+  },
+  {
+    "name" : "minecraft:element_11",
+    "id" : -22
+  },
+  {
+    "name" : "minecraft:element_110",
+    "id" : -121
+  },
+  {
+    "name" : "minecraft:element_111",
+    "id" : -122
+  },
+  {
+    "name" : "minecraft:element_112",
+    "id" : -123
+  },
+  {
+    "name" : "minecraft:element_113",
+    "id" : -124
+  },
+  {
+    "name" : "minecraft:element_114",
+    "id" : -125
+  },
+  {
+    "name" : "minecraft:element_115",
+    "id" : -126
+  },
+  {
+    "name" : "minecraft:element_116",
+    "id" : -127
+  },
+  {
+    "name" : "minecraft:element_117",
+    "id" : -128
+  },
+  {
+    "name" : "minecraft:element_118",
+    "id" : -129
+  },
+  {
+    "name" : "minecraft:element_12",
+    "id" : -23
+  },
+  {
+    "name" : "minecraft:element_13",
+    "id" : -24
+  },
+  {
+    "name" : "minecraft:element_14",
+    "id" : -25
+  },
+  {
+    "name" : "minecraft:element_15",
+    "id" : -26
+  },
+  {
+    "name" : "minecraft:element_16",
+    "id" : -27
+  },
+  {
+    "name" : "minecraft:element_17",
+    "id" : -28
+  },
+  {
+    "name" : "minecraft:element_18",
+    "id" : -29
+  },
+  {
+    "name" : "minecraft:element_19",
+    "id" : -30
+  },
+  {
+    "name" : "minecraft:element_2",
+    "id" : -13
+  },
+  {
+    "name" : "minecraft:element_20",
+    "id" : -31
+  },
+  {
+    "name" : "minecraft:element_21",
+    "id" : -32
+  },
+  {
+    "name" : "minecraft:element_22",
+    "id" : -33
+  },
+  {
+    "name" : "minecraft:element_23",
+    "id" : -34
+  },
+  {
+    "name" : "minecraft:element_24",
+    "id" : -35
+  },
+  {
+    "name" : "minecraft:element_25",
+    "id" : -36
+  },
+  {
+    "name" : "minecraft:element_26",
+    "id" : -37
+  },
+  {
+    "name" : "minecraft:element_27",
+    "id" : -38
+  },
+  {
+    "name" : "minecraft:element_28",
+    "id" : -39
+  },
+  {
+    "name" : "minecraft:element_29",
+    "id" : -40
+  },
+  {
+    "name" : "minecraft:element_3",
+    "id" : -14
+  },
+  {
+    "name" : "minecraft:element_30",
+    "id" : -41
+  },
+  {
+    "name" : "minecraft:element_31",
+    "id" : -42
+  },
+  {
+    "name" : "minecraft:element_32",
+    "id" : -43
+  },
+  {
+    "name" : "minecraft:element_33",
+    "id" : -44
+  },
+  {
+    "name" : "minecraft:element_34",
+    "id" : -45
+  },
+  {
+    "name" : "minecraft:element_35",
+    "id" : -46
+  },
+  {
+    "name" : "minecraft:element_36",
+    "id" : -47
+  },
+  {
+    "name" : "minecraft:element_37",
+    "id" : -48
+  },
+  {
+    "name" : "minecraft:element_38",
+    "id" : -49
+  },
+  {
+    "name" : "minecraft:element_39",
+    "id" : -50
+  },
+  {
+    "name" : "minecraft:element_4",
+    "id" : -15
+  },
+  {
+    "name" : "minecraft:element_40",
+    "id" : -51
+  },
+  {
+    "name" : "minecraft:element_41",
+    "id" : -52
+  },
+  {
+    "name" : "minecraft:element_42",
+    "id" : -53
+  },
+  {
+    "name" : "minecraft:element_43",
+    "id" : -54
+  },
+  {
+    "name" : "minecraft:element_44",
+    "id" : -55
+  },
+  {
+    "name" : "minecraft:element_45",
+    "id" : -56
+  },
+  {
+    "name" : "minecraft:element_46",
+    "id" : -57
+  },
+  {
+    "name" : "minecraft:element_47",
+    "id" : -58
+  },
+  {
+    "name" : "minecraft:element_48",
+    "id" : -59
+  },
+  {
+    "name" : "minecraft:element_49",
+    "id" : -60
+  },
+  {
+    "name" : "minecraft:element_5",
+    "id" : -16
+  },
+  {
+    "name" : "minecraft:element_50",
+    "id" : -61
+  },
+  {
+    "name" : "minecraft:element_51",
+    "id" : -62
+  },
+  {
+    "name" : "minecraft:element_52",
+    "id" : -63
+  },
+  {
+    "name" : "minecraft:element_53",
+    "id" : -64
+  },
+  {
+    "name" : "minecraft:element_54",
+    "id" : -65
+  },
+  {
+    "name" : "minecraft:element_55",
+    "id" : -66
+  },
+  {
+    "name" : "minecraft:element_56",
+    "id" : -67
+  },
+  {
+    "name" : "minecraft:element_57",
+    "id" : -68
+  },
+  {
+    "name" : "minecraft:element_58",
+    "id" : -69
+  },
+  {
+    "name" : "minecraft:element_59",
+    "id" : -70
+  },
+  {
+    "name" : "minecraft:element_6",
+    "id" : -17
+  },
+  {
+    "name" : "minecraft:element_60",
+    "id" : -71
+  },
+  {
+    "name" : "minecraft:element_61",
+    "id" : -72
+  },
+  {
+    "name" : "minecraft:element_62",
+    "id" : -73
+  },
+  {
+    "name" : "minecraft:element_63",
+    "id" : -74
+  },
+  {
+    "name" : "minecraft:element_64",
+    "id" : -75
+  },
+  {
+    "name" : "minecraft:element_65",
+    "id" : -76
+  },
+  {
+    "name" : "minecraft:element_66",
+    "id" : -77
+  },
+  {
+    "name" : "minecraft:element_67",
+    "id" : -78
+  },
+  {
+    "name" : "minecraft:element_68",
+    "id" : -79
+  },
+  {
+    "name" : "minecraft:element_69",
+    "id" : -80
+  },
+  {
+    "name" : "minecraft:element_7",
+    "id" : -18
+  },
+  {
+    "name" : "minecraft:element_70",
+    "id" : -81
+  },
+  {
+    "name" : "minecraft:element_71",
+    "id" : -82
+  },
+  {
+    "name" : "minecraft:element_72",
+    "id" : -83
+  },
+  {
+    "name" : "minecraft:element_73",
+    "id" : -84
+  },
+  {
+    "name" : "minecraft:element_74",
+    "id" : -85
+  },
+  {
+    "name" : "minecraft:element_75",
+    "id" : -86
+  },
+  {
+    "name" : "minecraft:element_76",
+    "id" : -87
+  },
+  {
+    "name" : "minecraft:element_77",
+    "id" : -88
+  },
+  {
+    "name" : "minecraft:element_78",
+    "id" : -89
+  },
+  {
+    "name" : "minecraft:element_79",
+    "id" : -90
+  },
+  {
+    "name" : "minecraft:element_8",
+    "id" : -19
+  },
+  {
+    "name" : "minecraft:element_80",
+    "id" : -91
+  },
+  {
+    "name" : "minecraft:element_81",
+    "id" : -92
+  },
+  {
+    "name" : "minecraft:element_82",
+    "id" : -93
+  },
+  {
+    "name" : "minecraft:element_83",
+    "id" : -94
+  },
+  {
+    "name" : "minecraft:element_84",
+    "id" : -95
+  },
+  {
+    "name" : "minecraft:element_85",
+    "id" : -96
+  },
+  {
+    "name" : "minecraft:element_86",
+    "id" : -97
+  },
+  {
+    "name" : "minecraft:element_87",
+    "id" : -98
+  },
+  {
+    "name" : "minecraft:element_88",
+    "id" : -99
+  },
+  {
+    "name" : "minecraft:element_89",
+    "id" : -100
+  },
+  {
+    "name" : "minecraft:element_9",
+    "id" : -20
+  },
+  {
+    "name" : "minecraft:element_90",
+    "id" : -101
+  },
+  {
+    "name" : "minecraft:element_91",
+    "id" : -102
+  },
+  {
+    "name" : "minecraft:element_92",
+    "id" : -103
+  },
+  {
+    "name" : "minecraft:element_93",
+    "id" : -104
+  },
+  {
+    "name" : "minecraft:element_94",
+    "id" : -105
+  },
+  {
+    "name" : "minecraft:element_95",
+    "id" : -106
+  },
+  {
+    "name" : "minecraft:element_96",
+    "id" : -107
+  },
+  {
+    "name" : "minecraft:element_97",
+    "id" : -108
+  },
+  {
+    "name" : "minecraft:element_98",
+    "id" : -109
+  },
+  {
+    "name" : "minecraft:element_99",
+    "id" : -110
+  },
+  {
+    "name" : "minecraft:elytra",
+    "id" : 554
+  },
+  {
+    "name" : "minecraft:emerald",
+    "id" : 502
+  },
+  {
+    "name" : "minecraft:emerald_block",
+    "id" : 133
+  },
+  {
+    "name" : "minecraft:emerald_ore",
+    "id" : 129
+  },
+  {
+    "name" : "minecraft:empty_map",
+    "id" : 505
+  },
+  {
+    "name" : "minecraft:enchanted_book",
+    "id" : 511
+  },
+  {
+    "name" : "minecraft:enchanted_golden_apple",
+    "id" : 259
+  },
+  {
+    "name" : "minecraft:enchanting_table",
+    "id" : 116
+  },
+  {
+    "name" : "minecraft:end_brick_stairs",
+    "id" : -178
+  },
+  {
+    "name" : "minecraft:end_bricks",
+    "id" : 206
+  },
+  {
+    "name" : "minecraft:end_crystal",
+    "id" : 615
+  },
+  {
+    "name" : "minecraft:end_gateway",
+    "id" : 209
+  },
+  {
+    "name" : "minecraft:end_portal",
+    "id" : 119
+  },
+  {
+    "name" : "minecraft:end_portal_frame",
+    "id" : 120
+  },
+  {
+    "name" : "minecraft:end_rod",
+    "id" : 208
+  },
+  {
+    "name" : "minecraft:end_stone",
+    "id" : 121
+  },
+  {
+    "name" : "minecraft:ender_chest",
+    "id" : 130
+  },
+  {
+    "name" : "minecraft:ender_eye",
+    "id" : 431
+  },
+  {
+    "name" : "minecraft:ender_pearl",
+    "id" : 420
+  },
+  {
+    "name" : "minecraft:enderman_spawn_egg",
+    "id" : 440
+  },
+  {
+    "name" : "minecraft:endermite_spawn_egg",
+    "id" : 458
+  },
+  {
+    "name" : "minecraft:evoker_spawn_egg",
+    "id" : 473
+  },
+  {
+    "name" : "minecraft:experience_bottle",
+    "id" : 498
+  },
+  {
+    "name" : "minecraft:farmland",
+    "id" : 60
+  },
+  {
+    "name" : "minecraft:feather",
+    "id" : 327
+  },
+  {
+    "name" : "minecraft:fence",
+    "id" : 85
+  },
+  {
+    "name" : "minecraft:fence_gate",
+    "id" : 107
+  },
+  {
+    "name" : "minecraft:fermented_spider_eye",
+    "id" : 426
+  },
+  {
+    "name" : "minecraft:field_masoned_banner_pattern",
+    "id" : 575
+  },
+  {
+    "name" : "minecraft:filled_map",
+    "id" : 418
+  },
+  {
+    "name" : "minecraft:fire",
+    "id" : 51
+  },
+  {
+    "name" : "minecraft:fire_charge",
+    "id" : 499
+  },
+  {
+    "name" : "minecraft:firework_rocket",
+    "id" : 509
+  },
+  {
+    "name" : "minecraft:firework_star",
+    "id" : 510
+  },
+  {
+    "name" : "minecraft:fishing_rod",
+    "id" : 390
+  },
+  {
+    "name" : "minecraft:fletching_table",
+    "id" : -201
+  },
+  {
+    "name" : "minecraft:flint",
+    "id" : 356
+  },
+  {
+    "name" : "minecraft:flint_and_steel",
+    "id" : 299
+  },
+  {
+    "name" : "minecraft:flower_banner_pattern",
+    "id" : 571
+  },
+  {
+    "name" : "minecraft:flower_pot",
+    "id" : 504
+  },
+  {
+    "name" : "minecraft:flowing_lava",
+    "id" : 10
+  },
+  {
+    "name" : "minecraft:flowing_water",
+    "id" : 8
+  },
+  {
+    "name" : "minecraft:fox_spawn_egg",
+    "id" : 488
+  },
+  {
+    "name" : "minecraft:frame",
+    "id" : 503
+  },
+  {
+    "name" : "minecraft:frosted_ice",
+    "id" : 207
+  },
+  {
+    "name" : "minecraft:furnace",
+    "id" : 61
+  },
+  {
+    "name" : "minecraft:ghast_spawn_egg",
+    "id" : 452
+  },
+  {
+    "name" : "minecraft:ghast_tear",
+    "id" : 422
+  },
+  {
+    "name" : "minecraft:gilded_blackstone",
+    "id" : -281
+  },
+  {
+    "name" : "minecraft:glass",
+    "id" : 20
+  },
+  {
+    "name" : "minecraft:glass_bottle",
+    "id" : 425
+  },
+  {
+    "name" : "minecraft:glass_pane",
+    "id" : 102
+  },
+  {
+    "name" : "minecraft:glistering_melon_slice",
+    "id" : 432
+  },
+  {
+    "name" : "minecraft:glow_stick",
+    "id" : 166
+  },
+  {
+    "name" : "minecraft:glowingobsidian",
+    "id" : 246
+  },
+  {
+    "name" : "minecraft:glowstone",
+    "id" : 89
+  },
+  {
+    "name" : "minecraft:glowstone_dust",
+    "id" : 392
+  },
+  {
+    "name" : "minecraft:gold_block",
+    "id" : 41
+  },
+  {
+    "name" : "minecraft:gold_ingot",
+    "id" : 306
+  },
+  {
+    "name" : "minecraft:gold_nugget",
+    "id" : 423
+  },
+  {
+    "name" : "minecraft:gold_ore",
+    "id" : 14
+  },
+  {
+    "name" : "minecraft:golden_apple",
+    "id" : 258
+  },
+  {
+    "name" : "minecraft:golden_axe",
+    "id" : 325
+  },
+  {
+    "name" : "minecraft:golden_boots",
+    "id" : 354
+  },
+  {
+    "name" : "minecraft:golden_carrot",
+    "id" : 283
+  },
+  {
+    "name" : "minecraft:golden_chestplate",
+    "id" : 352
+  },
+  {
+    "name" : "minecraft:golden_helmet",
+    "id" : 351
+  },
+  {
+    "name" : "minecraft:golden_hoe",
+    "id" : 333
+  },
+  {
+    "name" : "minecraft:golden_horse_armor",
+    "id" : 522
+  },
+  {
+    "name" : "minecraft:golden_leggings",
+    "id" : 353
+  },
+  {
+    "name" : "minecraft:golden_pickaxe",
+    "id" : 324
+  },
+  {
+    "name" : "minecraft:golden_rail",
+    "id" : 27
+  },
+  {
+    "name" : "minecraft:golden_shovel",
+    "id" : 323
+  },
+  {
+    "name" : "minecraft:golden_sword",
+    "id" : 322
+  },
+  {
+    "name" : "minecraft:granite_stairs",
+    "id" : -169
+  },
+  {
+    "name" : "minecraft:grass",
+    "id" : 2
+  },
+  {
+    "name" : "minecraft:grass_path",
+    "id" : 198
+  },
+  {
+    "name" : "minecraft:gravel",
+    "id" : 13
+  },
+  {
+    "name" : "minecraft:gray_dye",
+    "id" : 401
+  },
+  {
+    "name" : "minecraft:gray_glazed_terracotta",
+    "id" : 227
+  },
+  {
+    "name" : "minecraft:green_dye",
+    "id" : 395
+  },
+  {
+    "name" : "minecraft:green_glazed_terracotta",
+    "id" : 233
+  },
+  {
+    "name" : "minecraft:grindstone",
+    "id" : -195
+  },
+  {
+    "name" : "minecraft:guardian_spawn_egg",
+    "id" : 459
+  },
+  {
+    "name" : "minecraft:gunpowder",
+    "id" : 328
+  },
+  {
+    "name" : "minecraft:hard_glass",
+    "id" : 253
+  },
+  {
+    "name" : "minecraft:hard_glass_pane",
+    "id" : 190
+  },
+  {
+    "name" : "minecraft:hard_stained_glass",
+    "id" : 254
+  },
+  {
+    "name" : "minecraft:hard_stained_glass_pane",
+    "id" : 191
+  },
+  {
+    "name" : "minecraft:hardened_clay",
+    "id" : 172
+  },
+  {
+    "name" : "minecraft:hay_block",
+    "id" : 170
+  },
+  {
+    "name" : "minecraft:heart_of_the_sea",
+    "id" : 561
+  },
+  {
+    "name" : "minecraft:heavy_weighted_pressure_plate",
+    "id" : 148
+  },
+  {
+    "name" : "minecraft:hoglin_spawn_egg",
+    "id" : 494
+  },
+  {
+    "name" : "minecraft:honey_block",
+    "id" : -220
+  },
+  {
+    "name" : "minecraft:honey_bottle",
+    "id" : 581
+  },
+  {
+    "name" : "minecraft:honeycomb",
+    "id" : 580
+  },
+  {
+    "name" : "minecraft:honeycomb_block",
+    "id" : -221
+  },
+  {
+    "name" : "minecraft:hopper",
+    "id" : 517
+  },
+  {
+    "name" : "minecraft:hopper_minecart",
+    "id" : 516
+  },
+  {
+    "name" : "minecraft:horse_spawn_egg",
+    "id" : 456
+  },
+  {
+    "name" : "minecraft:husk_spawn_egg",
+    "id" : 461
+  },
+  {
+    "name" : "minecraft:ice",
+    "id" : 79
+  },
+  {
+    "name" : "minecraft:ice_bomb",
+    "id" : 584
+  },
+  {
+    "name" : "minecraft:info_update",
+    "id" : 248
+  },
+  {
+    "name" : "minecraft:info_update2",
+    "id" : 249
+  },
+  {
+    "name" : "minecraft:ink_sac",
+    "id" : 411
+  },
+  {
+    "name" : "minecraft:invisiblebedrock",
+    "id" : 95
+  },
+  {
+    "name" : "minecraft:iron_axe",
+    "id" : 298
+  },
+  {
+    "name" : "minecraft:iron_bars",
+    "id" : 101
+  },
+  {
+    "name" : "minecraft:iron_block",
+    "id" : 42
+  },
+  {
+    "name" : "minecraft:iron_boots",
+    "id" : 346
+  },
+  {
+    "name" : "minecraft:iron_chestplate",
+    "id" : 344
+  },
+  {
+    "name" : "minecraft:iron_door",
+    "id" : 370
+  },
+  {
+    "name" : "minecraft:iron_helmet",
+    "id" : 343
+  },
+  {
+    "name" : "minecraft:iron_hoe",
+    "id" : 331
+  },
+  {
+    "name" : "minecraft:iron_horse_armor",
+    "id" : 521
+  },
+  {
+    "name" : "minecraft:iron_ingot",
+    "id" : 305
+  },
+  {
+    "name" : "minecraft:iron_leggings",
+    "id" : 345
+  },
+  {
+    "name" : "minecraft:iron_nugget",
+    "id" : 559
+  },
+  {
+    "name" : "minecraft:iron_ore",
+    "id" : 15
+  },
+  {
+    "name" : "minecraft:iron_pickaxe",
+    "id" : 297
+  },
+  {
+    "name" : "minecraft:iron_shovel",
+    "id" : 296
+  },
+  {
+    "name" : "minecraft:iron_sword",
+    "id" : 307
+  },
+  {
+    "name" : "minecraft:iron_trapdoor",
+    "id" : 167
+  },
+  {
+    "name" : "minecraft:item.acacia_door",
+    "id" : 196
+  },
+  {
+    "name" : "minecraft:item.bed",
+    "id" : 26
+  },
+  {
+    "name" : "minecraft:item.beetroot",
+    "id" : 244
+  },
+  {
+    "name" : "minecraft:item.birch_door",
+    "id" : 194
+  },
+  {
+    "name" : "minecraft:item.cake",
+    "id" : 92
+  },
+  {
+    "name" : "minecraft:item.camera",
+    "id" : 242
+  },
+  {
+    "name" : "minecraft:item.campfire",
+    "id" : -209
+  },
+  {
+    "name" : "minecraft:item.cauldron",
+    "id" : 118
+  },
+  {
+    "name" : "minecraft:item.chain",
+    "id" : -286
+  },
+  {
+    "name" : "minecraft:item.crimson_door",
+    "id" : -244
+  },
+  {
+    "name" : "minecraft:item.dark_oak_door",
+    "id" : 197
+  },
+  {
+    "name" : "minecraft:item.flower_pot",
+    "id" : 140
+  },
+  {
+    "name" : "minecraft:item.frame",
+    "id" : 199
+  },
+  {
+    "name" : "minecraft:item.hopper",
+    "id" : 154
+  },
+  {
+    "name" : "minecraft:item.iron_door",
+    "id" : 71
+  },
+  {
+    "name" : "minecraft:item.jungle_door",
+    "id" : 195
+  },
+  {
+    "name" : "minecraft:item.kelp",
+    "id" : -138
+  },
+  {
+    "name" : "minecraft:item.nether_sprouts",
+    "id" : -238
+  },
+  {
+    "name" : "minecraft:item.nether_wart",
+    "id" : 115
+  },
+  {
+    "name" : "minecraft:item.reeds",
+    "id" : 83
+  },
+  {
+    "name" : "minecraft:item.skull",
+    "id" : 144
+  },
+  {
+    "name" : "minecraft:item.soul_campfire",
+    "id" : -290
+  },
+  {
+    "name" : "minecraft:item.spruce_door",
+    "id" : 193
+  },
+  {
+    "name" : "minecraft:item.warped_door",
+    "id" : -245
+  },
+  {
+    "name" : "minecraft:item.wheat",
+    "id" : 59
+  },
+  {
+    "name" : "minecraft:item.wooden_door",
+    "id" : 64
+  },
+  {
+    "name" : "minecraft:jigsaw",
+    "id" : -211
+  },
+  {
+    "name" : "minecraft:jukebox",
+    "id" : 84
+  },
+  {
+    "name" : "minecraft:jungle_boat",
+    "id" : 375
+  },
+  {
+    "name" : "minecraft:jungle_button",
+    "id" : -143
+  },
+  {
+    "name" : "minecraft:jungle_door",
+    "id" : 545
+  },
+  {
+    "name" : "minecraft:jungle_fence_gate",
+    "id" : 185
+  },
+  {
+    "name" : "minecraft:jungle_pressure_plate",
+    "id" : -153
+  },
+  {
+    "name" : "minecraft:jungle_sign",
+    "id" : 568
+  },
+  {
+    "name" : "minecraft:jungle_stairs",
+    "id" : 136
+  },
+  {
+    "name" : "minecraft:jungle_standing_sign",
+    "id" : -188
+  },
+  {
+    "name" : "minecraft:jungle_trapdoor",
+    "id" : -148
+  },
+  {
+    "name" : "minecraft:jungle_wall_sign",
+    "id" : -189
+  },
+  {
+    "name" : "minecraft:kelp",
+    "id" : 380
+  },
+  {
+    "name" : "minecraft:ladder",
+    "id" : 65
+  },
+  {
+    "name" : "minecraft:lantern",
+    "id" : -208
+  },
+  {
+    "name" : "minecraft:lapis_block",
+    "id" : 22
+  },
+  {
+    "name" : "minecraft:lapis_lazuli",
+    "id" : 412
+  },
+  {
+    "name" : "minecraft:lapis_ore",
+    "id" : 21
+  },
+  {
+    "name" : "minecraft:lava",
+    "id" : 11
+  },
+  {
+    "name" : "minecraft:lava_bucket",
+    "id" : 363
+  },
+  {
+    "name" : "minecraft:lava_cauldron",
+    "id" : -210
+  },
+  {
+    "name" : "minecraft:lead",
+    "id" : 537
+  },
+  {
+    "name" : "minecraft:leather",
+    "id" : 379
+  },
+  {
+    "name" : "minecraft:leather_boots",
+    "id" : 338
+  },
+  {
+    "name" : "minecraft:leather_chestplate",
+    "id" : 336
+  },
+  {
+    "name" : "minecraft:leather_helmet",
+    "id" : 335
+  },
+  {
+    "name" : "minecraft:leather_horse_armor",
+    "id" : 520
+  },
+  {
+    "name" : "minecraft:leather_leggings",
+    "id" : 337
+  },
+  {
+    "name" : "minecraft:leaves",
+    "id" : 18
+  },
+  {
+    "name" : "minecraft:leaves2",
+    "id" : 161
+  },
+  {
+    "name" : "minecraft:lectern",
+    "id" : -194
+  },
+  {
+    "name" : "minecraft:lever",
+    "id" : 69
+  },
+  {
+    "name" : "minecraft:light_block",
+    "id" : -215
+  },
+  {
+    "name" : "minecraft:light_blue_dye",
+    "id" : 405
+  },
+  {
+    "name" : "minecraft:light_blue_glazed_terracotta",
+    "id" : 223
+  },
+  {
+    "name" : "minecraft:light_gray_dye",
+    "id" : 400
+  },
+  {
+    "name" : "minecraft:light_weighted_pressure_plate",
+    "id" : 147
+  },
+  {
+    "name" : "minecraft:lime_dye",
+    "id" : 403
+  },
+  {
+    "name" : "minecraft:lime_glazed_terracotta",
+    "id" : 225
+  },
+  {
+    "name" : "minecraft:lingering_potion",
+    "id" : 552
+  },
+  {
+    "name" : "minecraft:lit_blast_furnace",
+    "id" : -214
+  },
+  {
+    "name" : "minecraft:lit_furnace",
+    "id" : 62
+  },
+  {
+    "name" : "minecraft:lit_pumpkin",
+    "id" : 91
+  },
+  {
+    "name" : "minecraft:lit_redstone_lamp",
+    "id" : 124
+  },
+  {
+    "name" : "minecraft:lit_redstone_ore",
+    "id" : 74
+  },
+  {
+    "name" : "minecraft:lit_smoker",
+    "id" : -199
+  },
+  {
+    "name" : "minecraft:llama_spawn_egg",
+    "id" : 471
+  },
+  {
+    "name" : "minecraft:lodestone",
+    "id" : -222
+  },
+  {
+    "name" : "minecraft:lodestone_compass",
+    "id" : 590
+  },
+  {
+    "name" : "minecraft:log",
+    "id" : 17
+  },
+  {
+    "name" : "minecraft:log2",
+    "id" : 162
+  },
+  {
+    "name" : "minecraft:loom",
+    "id" : -204
+  },
+  {
+    "name" : "minecraft:magenta_dye",
+    "id" : 406
+  },
+  {
+    "name" : "minecraft:magenta_glazed_terracotta",
+    "id" : 222
+  },
+  {
+    "name" : "minecraft:magma",
+    "id" : 213
+  },
+  {
+    "name" : "minecraft:magma_cream",
+    "id" : 428
+  },
+  {
+    "name" : "minecraft:magma_cube_spawn_egg",
+    "id" : 453
+  },
+  {
+    "name" : "minecraft:medicine",
+    "id" : 588
+  },
+  {
+    "name" : "minecraft:melon_block",
+    "id" : 103
+  },
+  {
+    "name" : "minecraft:melon_seeds",
+    "id" : 293
+  },
+  {
+    "name" : "minecraft:melon_slice",
+    "id" : 272
+  },
+  {
+    "name" : "minecraft:melon_stem",
+    "id" : 105
+  },
+  {
+    "name" : "minecraft:milk_bucket",
+    "id" : 361
+  },
+  {
+    "name" : "minecraft:minecart",
+    "id" : 368
+  },
+  {
+    "name" : "minecraft:mob_spawner",
+    "id" : 52
+  },
+  {
+    "name" : "minecraft:mojang_banner_pattern",
+    "id" : 574
+  },
+  {
+    "name" : "minecraft:monster_egg",
+    "id" : 97
+  },
+  {
+    "name" : "minecraft:mooshroom_spawn_egg",
+    "id" : 438
+  },
+  {
+    "name" : "minecraft:mossy_cobblestone",
+    "id" : 48
+  },
+  {
+    "name" : "minecraft:mossy_cobblestone_stairs",
+    "id" : -179
+  },
+  {
+    "name" : "minecraft:mossy_stone_brick_stairs",
+    "id" : -175
+  },
+  {
+    "name" : "minecraft:movingblock",
+    "id" : 250
+  },
+  {
+    "name" : "minecraft:mule_spawn_egg",
+    "id" : 464
+  },
+  {
+    "name" : "minecraft:mushroom_stew",
+    "id" : 260
+  },
+  {
+    "name" : "minecraft:music_disc_11",
+    "id" : 534
+  },
+  {
+    "name" : "minecraft:music_disc_13",
+    "id" : 524
+  },
+  {
+    "name" : "minecraft:music_disc_blocks",
+    "id" : 526
+  },
+  {
+    "name" : "minecraft:music_disc_cat",
+    "id" : 525
+  },
+  {
+    "name" : "minecraft:music_disc_chirp",
+    "id" : 527
+  },
+  {
+    "name" : "minecraft:music_disc_far",
+    "id" : 528
+  },
+  {
+    "name" : "minecraft:music_disc_mall",
+    "id" : 529
+  },
+  {
+    "name" : "minecraft:music_disc_mellohi",
+    "id" : 530
+  },
+  {
+    "name" : "minecraft:music_disc_pigstep",
+    "id" : 608
+  },
+  {
+    "name" : "minecraft:music_disc_stal",
+    "id" : 531
+  },
+  {
+    "name" : "minecraft:music_disc_strad",
+    "id" : 532
+  },
+  {
+    "name" : "minecraft:music_disc_wait",
+    "id" : 535
+  },
+  {
+    "name" : "minecraft:music_disc_ward",
+    "id" : 533
+  },
+  {
+    "name" : "minecraft:mutton",
+    "id" : 540
+  },
+  {
+    "name" : "minecraft:mycelium",
+    "id" : 110
+  },
+  {
+    "name" : "minecraft:name_tag",
+    "id" : 538
+  },
+  {
+    "name" : "minecraft:nautilus_shell",
+    "id" : 560
+  },
+  {
+    "name" : "minecraft:nether_brick",
+    "id" : 112
+  },
+  {
+    "name" : "minecraft:nether_brick_fence",
+    "id" : 113
+  },
+  {
+    "name" : "minecraft:nether_brick_stairs",
+    "id" : 114
+  },
+  {
+    "name" : "minecraft:nether_gold_ore",
+    "id" : -288
+  },
+  {
+    "name" : "minecraft:nether_sprouts",
+    "id" : 609
+  },
+  {
+    "name" : "minecraft:nether_star",
+    "id" : 508
+  },
+  {
+    "name" : "minecraft:nether_wart",
+    "id" : 294
+  },
+  {
+    "name" : "minecraft:nether_wart_block",
+    "id" : 214
+  },
+  {
+    "name" : "minecraft:netherbrick",
+    "id" : 513
+  },
+  {
+    "name" : "minecraft:netherite_axe",
+    "id" : 595
+  },
+  {
+    "name" : "minecraft:netherite_block",
+    "id" : -270
+  },
+  {
+    "name" : "minecraft:netherite_boots",
+    "id" : 600
+  },
+  {
+    "name" : "minecraft:netherite_chestplate",
+    "id" : 598
+  },
+  {
+    "name" : "minecraft:netherite_helmet",
+    "id" : 597
+  },
+  {
+    "name" : "minecraft:netherite_hoe",
+    "id" : 596
+  },
+  {
+    "name" : "minecraft:netherite_ingot",
+    "id" : 591
+  },
+  {
+    "name" : "minecraft:netherite_leggings",
+    "id" : 599
+  },
+  {
+    "name" : "minecraft:netherite_pickaxe",
+    "id" : 594
+  },
+  {
+    "name" : "minecraft:netherite_scrap",
+    "id" : 601
+  },
+  {
+    "name" : "minecraft:netherite_shovel",
+    "id" : 593
+  },
+  {
+    "name" : "minecraft:netherite_sword",
+    "id" : 592
+  },
+  {
+    "name" : "minecraft:netherrack",
+    "id" : 87
+  },
+  {
+    "name" : "minecraft:netherreactor",
+    "id" : 247
+  },
+  {
+    "name" : "minecraft:normal_stone_stairs",
+    "id" : -180
+  },
+  {
+    "name" : "minecraft:noteblock",
+    "id" : 25
+  },
+  {
+    "name" : "minecraft:npc_spawn_egg",
+    "id" : 468
+  },
+  {
+    "name" : "minecraft:oak_boat",
+    "id" : 373
+  },
+  {
+    "name" : "minecraft:oak_sign",
+    "id" : 358
+  },
+  {
+    "name" : "minecraft:oak_stairs",
+    "id" : 53
+  },
+  {
+    "name" : "minecraft:observer",
+    "id" : 251
+  },
+  {
+    "name" : "minecraft:obsidian",
+    "id" : 49
+  },
+  {
+    "name" : "minecraft:ocelot_spawn_egg",
+    "id" : 449
+  },
+  {
+    "name" : "minecraft:orange_dye",
+    "id" : 407
+  },
+  {
+    "name" : "minecraft:orange_glazed_terracotta",
+    "id" : 221
+  },
+  {
+    "name" : "minecraft:packed_ice",
+    "id" : 174
+  },
+  {
+    "name" : "minecraft:painting",
+    "id" : 357
+  },
+  {
+    "name" : "minecraft:panda_spawn_egg",
+    "id" : 487
+  },
+  {
+    "name" : "minecraft:paper",
+    "id" : 384
+  },
+  {
+    "name" : "minecraft:parrot_spawn_egg",
+    "id" : 476
+  },
+  {
+    "name" : "minecraft:phantom_membrane",
+    "id" : 564
+  },
+  {
+    "name" : "minecraft:phantom_spawn_egg",
+    "id" : 484
+  },
+  {
+    "name" : "minecraft:pig_spawn_egg",
+    "id" : 435
+  },
+  {
+    "name" : "minecraft:piglin_banner_pattern",
+    "id" : 577
+  },
+  {
+    "name" : "minecraft:piglin_brute_spawn_egg",
+    "id" : 497
+  },
+  {
+    "name" : "minecraft:piglin_spawn_egg",
+    "id" : 495
+  },
+  {
+    "name" : "minecraft:pillager_spawn_egg",
+    "id" : 489
+  },
+  {
+    "name" : "minecraft:pink_dye",
+    "id" : 402
+  },
+  {
+    "name" : "minecraft:pink_glazed_terracotta",
+    "id" : 226
+  },
+  {
+    "name" : "minecraft:piston",
+    "id" : 33
+  },
+  {
+    "name" : "minecraft:pistonarmcollision",
+    "id" : 34
+  },
+  {
+    "name" : "minecraft:planks",
+    "id" : 5
+  },
+  {
+    "name" : "minecraft:podzol",
+    "id" : 243
+  },
+  {
+    "name" : "minecraft:poisonous_potato",
+    "id" : 282
+  },
+  {
+    "name" : "minecraft:polar_bear_spawn_egg",
+    "id" : 470
+  },
+  {
+    "name" : "minecraft:polished_andesite_stairs",
+    "id" : -174
+  },
+  {
+    "name" : "minecraft:polished_basalt",
+    "id" : -235
+  },
+  {
+    "name" : "minecraft:polished_blackstone",
+    "id" : -291
+  },
+  {
+    "name" : "minecraft:polished_blackstone_brick_double_slab",
+    "id" : -285
+  },
+  {
+    "name" : "minecraft:polished_blackstone_brick_slab",
+    "id" : -284
+  },
+  {
+    "name" : "minecraft:polished_blackstone_brick_stairs",
+    "id" : -275
+  },
+  {
+    "name" : "minecraft:polished_blackstone_brick_wall",
+    "id" : -278
+  },
+  {
+    "name" : "minecraft:polished_blackstone_bricks",
+    "id" : -274
+  },
+  {
+    "name" : "minecraft:polished_blackstone_button",
+    "id" : -296
+  },
+  {
+    "name" : "minecraft:polished_blackstone_double_slab",
+    "id" : -294
+  },
+  {
+    "name" : "minecraft:polished_blackstone_pressure_plate",
+    "id" : -295
+  },
+  {
+    "name" : "minecraft:polished_blackstone_slab",
+    "id" : -293
+  },
+  {
+    "name" : "minecraft:polished_blackstone_stairs",
+    "id" : -292
+  },
+  {
+    "name" : "minecraft:polished_blackstone_wall",
+    "id" : -297
+  },
+  {
+    "name" : "minecraft:polished_diorite_stairs",
+    "id" : -173
+  },
+  {
+    "name" : "minecraft:polished_granite_stairs",
+    "id" : -172
+  },
+  {
+    "name" : "minecraft:popped_chorus_fruit",
+    "id" : 549
+  },
+  {
+    "name" : "minecraft:porkchop",
+    "id" : 262
+  },
+  {
+    "name" : "minecraft:portal",
+    "id" : 90
+  },
+  {
+    "name" : "minecraft:potato",
+    "id" : 280
+  },
+  {
+    "name" : "minecraft:potatoes",
+    "id" : 142
+  },
+  {
+    "name" : "minecraft:potion",
+    "id" : 424
+  },
+  {
+    "name" : "minecraft:powered_comparator",
+    "id" : 150
+  },
+  {
+    "name" : "minecraft:powered_repeater",
+    "id" : 94
+  },
+  {
+    "name" : "minecraft:prismarine",
+    "id" : 168
+  },
+  {
+    "name" : "minecraft:prismarine_bricks_stairs",
+    "id" : -4
+  },
+  {
+    "name" : "minecraft:prismarine_crystals",
+    "id" : 539
+  },
+  {
+    "name" : "minecraft:prismarine_shard",
+    "id" : 555
+  },
+  {
+    "name" : "minecraft:prismarine_stairs",
+    "id" : -2
+  },
+  {
+    "name" : "minecraft:pufferfish",
+    "id" : 267
+  },
+  {
+    "name" : "minecraft:pufferfish_bucket",
+    "id" : 367
+  },
+  {
+    "name" : "minecraft:pufferfish_spawn_egg",
+    "id" : 479
+  },
+  {
+    "name" : "minecraft:pumpkin",
+    "id" : 86
+  },
+  {
+    "name" : "minecraft:pumpkin_pie",
+    "id" : 284
+  },
+  {
+    "name" : "minecraft:pumpkin_seeds",
+    "id" : 292
+  },
+  {
+    "name" : "minecraft:pumpkin_stem",
+    "id" : 104
+  },
+  {
+    "name" : "minecraft:purple_dye",
+    "id" : 398
+  },
+  {
+    "name" : "minecraft:purple_glazed_terracotta",
+    "id" : 219
+  },
+  {
+    "name" : "minecraft:purpur_block",
+    "id" : 201
+  },
+  {
+    "name" : "minecraft:purpur_stairs",
+    "id" : 203
+  },
+  {
+    "name" : "minecraft:quartz",
+    "id" : 514
+  },
+  {
+    "name" : "minecraft:quartz_block",
+    "id" : 155
+  },
+  {
+    "name" : "minecraft:quartz_bricks",
+    "id" : -304
+  },
+  {
+    "name" : "minecraft:quartz_ore",
+    "id" : 153
+  },
+  {
+    "name" : "minecraft:quartz_stairs",
+    "id" : 156
+  },
+  {
+    "name" : "minecraft:rabbit",
+    "id" : 288
+  },
+  {
+    "name" : "minecraft:rabbit_foot",
+    "id" : 518
+  },
+  {
+    "name" : "minecraft:rabbit_hide",
+    "id" : 519
+  },
+  {
+    "name" : "minecraft:rabbit_spawn_egg",
+    "id" : 457
+  },
+  {
+    "name" : "minecraft:rabbit_stew",
+    "id" : 290
+  },
+  {
+    "name" : "minecraft:rail",
+    "id" : 66
+  },
+  {
+    "name" : "minecraft:rapid_fertilizer",
+    "id" : 586
+  },
+  {
+    "name" : "minecraft:ravager_spawn_egg",
+    "id" : 491
+  },
+  {
+    "name" : "minecraft:real_double_stone_slab",
+    "id" : 43
+  },
+  {
+    "name" : "minecraft:real_double_stone_slab2",
+    "id" : 181
+  },
+  {
+    "name" : "minecraft:real_double_stone_slab3",
+    "id" : -167
+  },
+  {
+    "name" : "minecraft:real_double_stone_slab4",
+    "id" : -168
+  },
+  {
+    "name" : "minecraft:red_dye",
+    "id" : 394
+  },
+  {
+    "name" : "minecraft:red_flower",
+    "id" : 38
+  },
+  {
+    "name" : "minecraft:red_glazed_terracotta",
+    "id" : 234
+  },
+  {
+    "name" : "minecraft:red_mushroom",
+    "id" : 40
+  },
+  {
+    "name" : "minecraft:red_mushroom_block",
+    "id" : 100
+  },
+  {
+    "name" : "minecraft:red_nether_brick",
+    "id" : 215
+  },
+  {
+    "name" : "minecraft:red_nether_brick_stairs",
+    "id" : -184
+  },
+  {
+    "name" : "minecraft:red_sandstone",
+    "id" : 179
+  },
+  {
+    "name" : "minecraft:red_sandstone_stairs",
+    "id" : 180
+  },
+  {
+    "name" : "minecraft:redstone",
+    "id" : 371
+  },
+  {
+    "name" : "minecraft:redstone_block",
+    "id" : 152
+  },
+  {
+    "name" : "minecraft:redstone_lamp",
+    "id" : 123
+  },
+  {
+    "name" : "minecraft:redstone_ore",
+    "id" : 73
+  },
+  {
+    "name" : "minecraft:redstone_torch",
+    "id" : 76
+  },
+  {
+    "name" : "minecraft:redstone_wire",
+    "id" : 55
+  },
+  {
+    "name" : "minecraft:repeater",
+    "id" : 417
+  },
+  {
+    "name" : "minecraft:repeating_command_block",
+    "id" : 188
+  },
+  {
+    "name" : "minecraft:reserved6",
+    "id" : 255
+  },
+  {
+    "name" : "minecraft:respawn_anchor",
+    "id" : -272
+  },
+  {
+    "name" : "minecraft:rotten_flesh",
+    "id" : 277
+  },
+  {
+    "name" : "minecraft:saddle",
+    "id" : 369
+  },
+  {
+    "name" : "minecraft:salmon",
+    "id" : 265
+  },
+  {
+    "name" : "minecraft:salmon_bucket",
+    "id" : 365
+  },
+  {
+    "name" : "minecraft:salmon_spawn_egg",
+    "id" : 480
+  },
+  {
+    "name" : "minecraft:sand",
+    "id" : 12
+  },
+  {
+    "name" : "minecraft:sandstone",
+    "id" : 24
+  },
+  {
+    "name" : "minecraft:sandstone_stairs",
+    "id" : 128
+  },
+  {
+    "name" : "minecraft:sapling",
+    "id" : 6
+  },
+  {
+    "name" : "minecraft:scaffolding",
+    "id" : -165
+  },
+  {
+    "name" : "minecraft:scute",
+    "id" : 562
+  },
+  {
+    "name" : "minecraft:sea_pickle",
+    "id" : -156
+  },
+  {
+    "name" : "minecraft:seagrass",
+    "id" : -130
+  },
+  {
+    "name" : "minecraft:sealantern",
+    "id" : 169
+  },
+  {
+    "name" : "minecraft:shears",
+    "id" : 419
+  },
+  {
+    "name" : "minecraft:sheep_spawn_egg",
+    "id" : 436
+  },
+  {
+    "name" : "minecraft:shield",
+    "id" : 355
+  },
+  {
+    "name" : "minecraft:shroomlight",
+    "id" : -230
+  },
+  {
+    "name" : "minecraft:shulker_box",
+    "id" : 218
+  },
+  {
+    "name" : "minecraft:shulker_shell",
+    "id" : 556
+  },
+  {
+    "name" : "minecraft:shulker_spawn_egg",
+    "id" : 467
+  },
+  {
+    "name" : "minecraft:silver_glazed_terracotta",
+    "id" : 228
+  },
+  {
+    "name" : "minecraft:silverfish_spawn_egg",
+    "id" : 441
+  },
+  {
+    "name" : "minecraft:skeleton_horse_spawn_egg",
+    "id" : 465
+  },
+  {
+    "name" : "minecraft:skeleton_spawn_egg",
+    "id" : 442
+  },
+  {
+    "name" : "minecraft:skull",
+    "id" : 506
+  },
+  {
+    "name" : "minecraft:skull_banner_pattern",
+    "id" : 573
+  },
+  {
+    "name" : "minecraft:slime",
+    "id" : 165
+  },
+  {
+    "name" : "minecraft:slime_ball",
+    "id" : 386
+  },
+  {
+    "name" : "minecraft:slime_spawn_egg",
+    "id" : 443
+  },
+  {
+    "name" : "minecraft:smithing_table",
+    "id" : -202
+  },
+  {
+    "name" : "minecraft:smoker",
+    "id" : -198
+  },
+  {
+    "name" : "minecraft:smooth_quartz_stairs",
+    "id" : -185
+  },
+  {
+    "name" : "minecraft:smooth_red_sandstone_stairs",
+    "id" : -176
+  },
+  {
+    "name" : "minecraft:smooth_sandstone_stairs",
+    "id" : -177
+  },
+  {
+    "name" : "minecraft:smooth_stone",
+    "id" : -183
+  },
+  {
+    "name" : "minecraft:snow",
+    "id" : 80
+  },
+  {
+    "name" : "minecraft:snow_layer",
+    "id" : 78
+  },
+  {
+    "name" : "minecraft:snowball",
+    "id" : 372
+  },
+  {
+    "name" : "minecraft:soul_campfire",
+    "id" : 610
+  },
+  {
+    "name" : "minecraft:soul_fire",
+    "id" : -237
+  },
+  {
+    "name" : "minecraft:soul_lantern",
+    "id" : -269
+  },
+  {
+    "name" : "minecraft:soul_sand",
+    "id" : 88
+  },
+  {
+    "name" : "minecraft:soul_soil",
+    "id" : -236
+  },
+  {
+    "name" : "minecraft:soul_torch",
+    "id" : -268
+  },
+  {
+    "name" : "minecraft:sparkler",
+    "id" : 589
+  },
+  {
+    "name" : "minecraft:spawn_egg",
+    "id" : 614
+  },
+  {
+    "name" : "minecraft:spider_eye",
+    "id" : 278
+  },
+  {
+    "name" : "minecraft:spider_spawn_egg",
+    "id" : 444
+  },
+  {
+    "name" : "minecraft:splash_potion",
+    "id" : 551
+  },
+  {
+    "name" : "minecraft:sponge",
+    "id" : 19
+  },
+  {
+    "name" : "minecraft:spruce_boat",
+    "id" : 376
+  },
+  {
+    "name" : "minecraft:spruce_button",
+    "id" : -144
+  },
+  {
+    "name" : "minecraft:spruce_door",
+    "id" : 543
+  },
+  {
+    "name" : "minecraft:spruce_fence_gate",
+    "id" : 183
+  },
+  {
+    "name" : "minecraft:spruce_pressure_plate",
+    "id" : -154
+  },
+  {
+    "name" : "minecraft:spruce_sign",
+    "id" : 566
+  },
+  {
+    "name" : "minecraft:spruce_stairs",
+    "id" : 134
+  },
+  {
+    "name" : "minecraft:spruce_standing_sign",
+    "id" : -181
+  },
+  {
+    "name" : "minecraft:spruce_trapdoor",
+    "id" : -149
+  },
+  {
+    "name" : "minecraft:spruce_wall_sign",
+    "id" : -182
+  },
+  {
+    "name" : "minecraft:squid_spawn_egg",
+    "id" : 448
+  },
+  {
+    "name" : "minecraft:stained_glass",
+    "id" : 241
+  },
+  {
+    "name" : "minecraft:stained_glass_pane",
+    "id" : 160
+  },
+  {
+    "name" : "minecraft:stained_hardened_clay",
+    "id" : 159
+  },
+  {
+    "name" : "minecraft:standing_banner",
+    "id" : 176
+  },
+  {
+    "name" : "minecraft:standing_sign",
+    "id" : 63
+  },
+  {
+    "name" : "minecraft:stick",
+    "id" : 320
+  },
+  {
+    "name" : "minecraft:sticky_piston",
+    "id" : 29
+  },
+  {
+    "name" : "minecraft:stickypistonarmcollision",
+    "id" : -217
+  },
+  {
+    "name" : "minecraft:stone",
+    "id" : 1
+  },
+  {
+    "name" : "minecraft:stone_axe",
+    "id" : 315
+  },
+  {
+    "name" : "minecraft:stone_brick_stairs",
+    "id" : 109
+  },
+  {
+    "name" : "minecraft:stone_button",
+    "id" : 77
+  },
+  {
+    "name" : "minecraft:stone_hoe",
+    "id" : 330
+  },
+  {
+    "name" : "minecraft:stone_pickaxe",
+    "id" : 314
+  },
+  {
+    "name" : "minecraft:stone_pressure_plate",
+    "id" : 70
+  },
+  {
+    "name" : "minecraft:stone_shovel",
+    "id" : 313
+  },
+  {
+    "name" : "minecraft:stone_stairs",
+    "id" : 67
+  },
+  {
+    "name" : "minecraft:stone_sword",
+    "id" : 312
+  },
+  {
+    "name" : "minecraft:stonebrick",
+    "id" : 98
+  },
+  {
+    "name" : "minecraft:stonecutter",
+    "id" : 245
+  },
+  {
+    "name" : "minecraft:stonecutter_block",
+    "id" : -197
+  },
+  {
+    "name" : "minecraft:stray_spawn_egg",
+    "id" : 460
+  },
+  {
+    "name" : "minecraft:strider_spawn_egg",
+    "id" : 493
+  },
+  {
+    "name" : "minecraft:string",
+    "id" : 326
+  },
+  {
+    "name" : "minecraft:stripped_acacia_log",
+    "id" : -8
+  },
+  {
+    "name" : "minecraft:stripped_birch_log",
+    "id" : -6
+  },
+  {
+    "name" : "minecraft:stripped_crimson_hyphae",
+    "id" : -300
+  },
+  {
+    "name" : "minecraft:stripped_crimson_stem",
+    "id" : -240
+  },
+  {
+    "name" : "minecraft:stripped_dark_oak_log",
+    "id" : -9
+  },
+  {
+    "name" : "minecraft:stripped_jungle_log",
+    "id" : -7
+  },
+  {
+    "name" : "minecraft:stripped_oak_log",
+    "id" : -10
+  },
+  {
+    "name" : "minecraft:stripped_spruce_log",
+    "id" : -5
+  },
+  {
+    "name" : "minecraft:stripped_warped_hyphae",
+    "id" : -301
+  },
+  {
+    "name" : "minecraft:stripped_warped_stem",
+    "id" : -241
+  },
+  {
+    "name" : "minecraft:structure_block",
+    "id" : 252
+  },
+  {
+    "name" : "minecraft:structure_void",
+    "id" : 217
+  },
+  {
+    "name" : "minecraft:sugar",
+    "id" : 414
+  },
+  {
+    "name" : "minecraft:sugar_cane",
+    "id" : 383
+  },
+  {
+    "name" : "minecraft:suspicious_stew",
+    "id" : 579
+  },
+  {
+    "name" : "minecraft:sweet_berries",
+    "id" : 287
+  },
+  {
+    "name" : "minecraft:sweet_berry_bush",
+    "id" : -207
+  },
+  {
+    "name" : "minecraft:tallgrass",
+    "id" : 31
+  },
+  {
+    "name" : "minecraft:target",
+    "id" : -239
+  },
+  {
+    "name" : "minecraft:tnt",
+    "id" : 46
+  },
+  {
+    "name" : "minecraft:tnt_minecart",
+    "id" : 515
+  },
+  {
+    "name" : "minecraft:torch",
+    "id" : 50
+  },
+  {
+    "name" : "minecraft:totem_of_undying",
+    "id" : 558
+  },
+  {
+    "name" : "minecraft:trapdoor",
+    "id" : 96
+  },
+  {
+    "name" : "minecraft:trapped_chest",
+    "id" : 146
+  },
+  {
+    "name" : "minecraft:trident",
+    "id" : 536
+  },
+  {
+    "name" : "minecraft:tripwire",
+    "id" : 132
+  },
+  {
+    "name" : "minecraft:tripwire_hook",
+    "id" : 131
+  },
+  {
+    "name" : "minecraft:tropical_fish",
+    "id" : 266
+  },
+  {
+    "name" : "minecraft:tropical_fish_bucket",
+    "id" : 366
+  },
+  {
+    "name" : "minecraft:tropical_fish_spawn_egg",
+    "id" : 477
+  },
+  {
+    "name" : "minecraft:turtle_egg",
+    "id" : -159
+  },
+  {
+    "name" : "minecraft:turtle_helmet",
+    "id" : 563
+  },
+  {
+    "name" : "minecraft:turtle_spawn_egg",
+    "id" : 483
+  },
+  {
+    "name" : "minecraft:twisting_vines",
+    "id" : -287
+  },
+  {
+    "name" : "minecraft:underwater_torch",
+    "id" : 239
+  },
+  {
+    "name" : "minecraft:undyed_shulker_box",
+    "id" : 205
+  },
+  {
+    "name" : "minecraft:unknown",
+    "id" : -305
+  },
+  {
+    "name" : "minecraft:unlit_redstone_torch",
+    "id" : 75
+  },
+  {
+    "name" : "minecraft:unpowered_comparator",
+    "id" : 149
+  },
+  {
+    "name" : "minecraft:unpowered_repeater",
+    "id" : 93
+  },
+  {
+    "name" : "minecraft:vex_spawn_egg",
+    "id" : 474
+  },
+  {
+    "name" : "minecraft:villager_spawn_egg",
+    "id" : 447
+  },
+  {
+    "name" : "minecraft:vindicator_spawn_egg",
+    "id" : 472
+  },
+  {
+    "name" : "minecraft:vine",
+    "id" : 106
+  },
+  {
+    "name" : "minecraft:wall_banner",
+    "id" : 177
+  },
+  {
+    "name" : "minecraft:wall_sign",
+    "id" : 68
+  },
+  {
+    "name" : "minecraft:wandering_trader_spawn_egg",
+    "id" : 490
+  },
+  {
+    "name" : "minecraft:warped_button",
+    "id" : -261
+  },
+  {
+    "name" : "minecraft:warped_door",
+    "id" : 605
+  },
+  {
+    "name" : "minecraft:warped_double_slab",
+    "id" : -267
+  },
+  {
+    "name" : "minecraft:warped_fence",
+    "id" : -257
+  },
+  {
+    "name" : "minecraft:warped_fence_gate",
+    "id" : -259
+  },
+  {
+    "name" : "minecraft:warped_fungus",
+    "id" : -229
+  },
+  {
+    "name" : "minecraft:warped_fungus_on_a_stick",
+    "id" : 606
+  },
+  {
+    "name" : "minecraft:warped_hyphae",
+    "id" : -298
+  },
+  {
+    "name" : "minecraft:warped_nylium",
+    "id" : -233
+  },
+  {
+    "name" : "minecraft:warped_planks",
+    "id" : -243
+  },
+  {
+    "name" : "minecraft:warped_pressure_plate",
+    "id" : -263
+  },
+  {
+    "name" : "minecraft:warped_roots",
+    "id" : -224
+  },
+  {
+    "name" : "minecraft:warped_sign",
+    "id" : 603
+  },
+  {
+    "name" : "minecraft:warped_slab",
+    "id" : -265
+  },
+  {
+    "name" : "minecraft:warped_stairs",
+    "id" : -255
+  },
+  {
+    "name" : "minecraft:warped_standing_sign",
+    "id" : -251
+  },
+  {
+    "name" : "minecraft:warped_stem",
+    "id" : -226
+  },
+  {
+    "name" : "minecraft:warped_trapdoor",
+    "id" : -247
+  },
+  {
+    "name" : "minecraft:warped_wall_sign",
+    "id" : -253
+  },
+  {
+    "name" : "minecraft:warped_wart_block",
+    "id" : -227
+  },
+  {
+    "name" : "minecraft:water",
+    "id" : 9
+  },
+  {
+    "name" : "minecraft:water_bucket",
+    "id" : 362
+  },
+  {
+    "name" : "minecraft:waterlily",
+    "id" : 111
+  },
+  {
+    "name" : "minecraft:web",
+    "id" : 30
+  },
+  {
+    "name" : "minecraft:weeping_vines",
+    "id" : -231
+  },
+  {
+    "name" : "minecraft:wheat",
+    "id" : 334
+  },
+  {
+    "name" : "minecraft:wheat_seeds",
+    "id" : 291
+  },
+  {
+    "name" : "minecraft:white_dye",
+    "id" : 408
+  },
+  {
+    "name" : "minecraft:white_glazed_terracotta",
+    "id" : 220
+  },
+  {
+    "name" : "minecraft:witch_spawn_egg",
+    "id" : 450
+  },
+  {
+    "name" : "minecraft:wither_rose",
+    "id" : -216
+  },
+  {
+    "name" : "minecraft:wither_skeleton_spawn_egg",
+    "id" : 462
+  },
+  {
+    "name" : "minecraft:wolf_spawn_egg",
+    "id" : 437
+  },
+  {
+    "name" : "minecraft:wood",
+    "id" : -212
+  },
+  {
+    "name" : "minecraft:wooden_axe",
+    "id" : 311
+  },
+  {
+    "name" : "minecraft:wooden_button",
+    "id" : 143
+  },
+  {
+    "name" : "minecraft:wooden_door",
+    "id" : 359
+  },
+  {
+    "name" : "minecraft:wooden_hoe",
+    "id" : 329
+  },
+  {
+    "name" : "minecraft:wooden_pickaxe",
+    "id" : 310
+  },
+  {
+    "name" : "minecraft:wooden_pressure_plate",
+    "id" : 72
+  },
+  {
+    "name" : "minecraft:wooden_shovel",
+    "id" : 309
+  },
+  {
+    "name" : "minecraft:wooden_slab",
+    "id" : 158
+  },
+  {
+    "name" : "minecraft:wooden_sword",
+    "id" : 308
+  },
+  {
+    "name" : "minecraft:wool",
+    "id" : 35
+  },
+  {
+    "name" : "minecraft:writable_book",
+    "id" : 500
+  },
+  {
+    "name" : "minecraft:written_book",
+    "id" : 501
+  },
+  {
+    "name" : "minecraft:yellow_dye",
+    "id" : 404
+  },
+  {
+    "name" : "minecraft:yellow_flower",
+    "id" : 37
+  },
+  {
+    "name" : "minecraft:yellow_glazed_terracotta",
+    "id" : 224
+  },
+  {
+    "name" : "minecraft:zoglin_spawn_egg",
+    "id" : 496
+  },
+  {
+    "name" : "minecraft:zombie_horse_spawn_egg",
+    "id" : 466
+  },
+  {
+    "name" : "minecraft:zombie_pigman_spawn_egg",
+    "id" : 446
+  },
+  {
+    "name" : "minecraft:zombie_spawn_egg",
+    "id" : 445
+  },
+  {
+    "name" : "minecraft:zombie_villager_spawn_egg",
+    "id" : 475
+  }
+]

--- a/src/main/java/org/geysermc/generator/Main.java
+++ b/src/main/java/org/geysermc/generator/Main.java
@@ -22,6 +22,8 @@ public class Main {
         generator.generateBlocks();
         generator.generateSounds();
 
-        // todo: don't map candles to sea_pickles and candle_cakes to cakes once bedrock gets them
+        // todo: the following items/blocks to be remapped properly once added to bedrock edition
+        // bundle
+        // candle, candle_cakes, potted_azalea,
     }
 }

--- a/src/main/java/org/geysermc/generator/MappingsGenerator.java
+++ b/src/main/java/org/geysermc/generator/MappingsGenerator.java
@@ -278,7 +278,7 @@ public class MappingsGenerator {
         sameNameAddedItems.add("Bedrock item names that are new and are in Java:");
         differentNameAddedItems.add("Bedrock item names that are new and are not in Java:");
         sameNameIdChanges.add("Bedrock item names that have had their IDs changed, and are in Java:");
-        differentNameIdChanges.add("Bedrock item names have had their IDs changed, and are not in Java:");
+        differentNameIdChanges.add("Bedrock item names that have had their IDs changed, and are not in Java:");
 
         for (String existingName : oldRuntimeIds.keySet()) {
             if (!newRuntimeIds.containsKey(existingName)) {

--- a/src/main/java/org/geysermc/generator/MappingsGenerator.java
+++ b/src/main/java/org/geysermc/generator/MappingsGenerator.java
@@ -161,13 +161,15 @@ public class MappingsGenerator {
             }
 
             try {
+                // Get all a map of all the bedrock names and their ids
                 Type listType = new TypeToken<List<PaletteItemEntry>>(){}.getType();
                 List<PaletteItemEntry> entries = GSON.fromJson(new FileReader(itemPalette), listType);
                 entries.forEach(item -> RUNTIME_ITEM_IDS.put(item.getIdentifier(), item.getLegacy_id()));
 
+                // Now, we transform the map so that all keys are java names and bedrock ids
                 // Fix some discrepancies - identifier is the Java string and ID is the Bedrock number ID
 
-                // Conflicts
+                // Conflicts - both names exist on each platform but they are different blocks
                 RUNTIME_ITEM_IDS.put("minecraft:grass", RUNTIME_ITEM_IDS.get("minecraft:tallgrass")); // Conflicts with grass block
                 RUNTIME_ITEM_IDS.put("minecraft:map", RUNTIME_ITEM_IDS.get("minecraft:empty_map")); // Conflicts with filled map
                 RUNTIME_ITEM_IDS.put("minecraft:melon", RUNTIME_ITEM_IDS.get("minecraft:melon_block")); // Conflicts with melon slice
@@ -175,7 +177,7 @@ public class MappingsGenerator {
                 RUNTIME_ITEM_IDS.put("minecraft:stone_stairs", RUNTIME_ITEM_IDS.get("minecraft:normal_stone_stairs")); // Conflicts with cobblestone stairs
                 RUNTIME_ITEM_IDS.put("minecraft:stonecutter", RUNTIME_ITEM_IDS.get("minecraft:stonecutter_block")); // Conflicts with, surprisingly, the OLD MCPE stonecutter
 
-                // Changed names
+                // Changed names - the block has a different name on java edition, so we add a new key with the same value. the old bedrock name key stays, with zero use.
                 RUNTIME_ITEM_IDS.put("minecraft:glow_item_frame", RUNTIME_ITEM_IDS.get("minecraft:glow_frame"));
                 RUNTIME_ITEM_IDS.put("minecraft:item_frame", RUNTIME_ITEM_IDS.get("minecraft:frame"));
                 RUNTIME_ITEM_IDS.put("minecraft:oak_door", RUNTIME_ITEM_IDS.get("minecraft:wooden_door"));
@@ -183,7 +185,7 @@ public class MappingsGenerator {
                 RUNTIME_ITEM_IDS.put("minecraft:small_dripleaf", RUNTIME_ITEM_IDS.get("minecraft:small_dripleaf_block"));
                 RUNTIME_ITEM_IDS.put("minecraft:waxed_copper_block", RUNTIME_ITEM_IDS.get("minecraft:waxed_copper"));
 
-                // Item replacements
+                // Item replacements - if an item doesn't exist on bedrock edition, we set it to something that does
                 RUNTIME_ITEM_IDS.put("minecraft:globe_banner_pattern", RUNTIME_ITEM_IDS.get("minecraft:banner_pattern"));
                 RUNTIME_ITEM_IDS.put("minecraft:trader_llama_spawn_egg", RUNTIME_ITEM_IDS.get("minecraft:llama_spawn_egg"));
                 RUNTIME_ITEM_IDS.put("minecraft:sculk_sensor", RUNTIME_ITEM_IDS.get("minecraft:info_update")); // soon
@@ -573,6 +575,8 @@ public class MappingsGenerator {
                 if (replacementIdentifier != null) {
                     object.addProperty("bedrock_id", RUNTIME_ITEM_IDS.get("minecraft:" + replacementIdentifier));
                 } else {
+                    // Add a sout here if you want to see which java item names aren't in RUNTIME_ITEM_IDS
+                    // Such items exist because the don't have the same name as the bedrock counterpart, and they haven't been added manually to RUNTIME_ITEM_IDS in this file
                     object.addProperty("bedrock_id", itemEntry.getBedrockId());
                 }
             }
@@ -593,6 +597,9 @@ public class MappingsGenerator {
         } else {
             object.addProperty("bedrock_id", 248); // update block (missing mapping)
             object.addProperty("bedrock_data", 0);
+        }
+        if (object.get("bedrock_id").getAsInt() == 248) {
+            System.out.println("Failed to map " + identifier + " to a bedrock ID other than the update block");
         }
         if (stackSize != 64) {
             object.addProperty("stack_size", stackSize);

--- a/src/main/java/org/geysermc/generator/MappingsGenerator.java
+++ b/src/main/java/org/geysermc/generator/MappingsGenerator.java
@@ -143,6 +143,7 @@ public class MappingsGenerator {
         try {
             File mappings = new File("mappings/items.json");
             File itemPalette = new File("palettes/runtime_item_states.json");
+            File oldItemPalette = new File("palettes/old_runtime_item_states.json");
             if (!mappings.exists()) {
                 System.out.println("Could not find mappings submodule! Did you clone them?");
                 return;
@@ -165,34 +166,43 @@ public class MappingsGenerator {
                 Type listType = new TypeToken<List<PaletteItemEntry>>(){}.getType();
                 List<PaletteItemEntry> entries = GSON.fromJson(new FileReader(itemPalette), listType);
                 entries.forEach(item -> RUNTIME_ITEM_IDS.put(item.getIdentifier(), item.getLegacy_id()));
-
-                // Now, we transform the map so that all keys are java names and bedrock ids
-                // Fix some discrepancies - identifier is the Java string and ID is the Bedrock number ID
-
-                // Conflicts - both names exist on each platform but they are different blocks
-                RUNTIME_ITEM_IDS.put("minecraft:grass", RUNTIME_ITEM_IDS.get("minecraft:tallgrass")); // Conflicts with grass block
-                RUNTIME_ITEM_IDS.put("minecraft:map", RUNTIME_ITEM_IDS.get("minecraft:empty_map")); // Conflicts with filled map
-                RUNTIME_ITEM_IDS.put("minecraft:melon", RUNTIME_ITEM_IDS.get("minecraft:melon_block")); // Conflicts with melon slice
-                RUNTIME_ITEM_IDS.put("minecraft:snow", RUNTIME_ITEM_IDS.get("minecraft:snow_layer")); // Conflicts with snow block
-                RUNTIME_ITEM_IDS.put("minecraft:stone_stairs", RUNTIME_ITEM_IDS.get("minecraft:normal_stone_stairs")); // Conflicts with cobblestone stairs
-                RUNTIME_ITEM_IDS.put("minecraft:stonecutter", RUNTIME_ITEM_IDS.get("minecraft:stonecutter_block")); // Conflicts with, surprisingly, the OLD MCPE stonecutter
-
-                // Changed names - the block has a different name on java edition, so we add a new key with the same value. the old bedrock name key stays, with zero use.
-                RUNTIME_ITEM_IDS.put("minecraft:glow_item_frame", RUNTIME_ITEM_IDS.get("minecraft:glow_frame"));
-                RUNTIME_ITEM_IDS.put("minecraft:item_frame", RUNTIME_ITEM_IDS.get("minecraft:frame"));
-                RUNTIME_ITEM_IDS.put("minecraft:oak_door", RUNTIME_ITEM_IDS.get("minecraft:wooden_door"));
-                RUNTIME_ITEM_IDS.put("minecraft:shulker_box", RUNTIME_ITEM_IDS.get("minecraft:undyed_shulker_box"));
-                RUNTIME_ITEM_IDS.put("minecraft:small_dripleaf", RUNTIME_ITEM_IDS.get("minecraft:small_dripleaf_block"));
-                RUNTIME_ITEM_IDS.put("minecraft:waxed_copper_block", RUNTIME_ITEM_IDS.get("minecraft:waxed_copper"));
-
-                // Item replacements - if an item doesn't exist on bedrock edition, we set it to something that does
-                RUNTIME_ITEM_IDS.put("minecraft:globe_banner_pattern", RUNTIME_ITEM_IDS.get("minecraft:banner_pattern"));
-                RUNTIME_ITEM_IDS.put("minecraft:trader_llama_spawn_egg", RUNTIME_ITEM_IDS.get("minecraft:llama_spawn_egg"));
-                RUNTIME_ITEM_IDS.put("minecraft:sculk_sensor", RUNTIME_ITEM_IDS.get("minecraft:info_update")); // soon
-                RUNTIME_ITEM_IDS.put("minecraft:zombified_piglin_spawn_egg", RUNTIME_ITEM_IDS.get("minecraft:zombie_pigman_spawn_egg"));
             } catch (FileNotFoundException ex) {
                 ex.printStackTrace();
+                return;
             }
+
+            if (!oldItemPalette.exists()) {
+                System.out.println("Could not find old bedrock item palette (old_runtime_item_states.json), not creating difference file with the current item palette.");
+            } else {
+                createItemDiff(new HashMap<>(RUNTIME_ITEM_IDS), oldItemPalette);
+                System.out.println("A difference file to compare an old bedrock palette to the new bedrock palette has been created (bedrock_item_diff.txt).");
+            }
+
+            // Now, we transform the map so that there is a key for every java name string, bedrock ID as the value
+            // Fix some discrepancies:
+
+            // Conflicts - both names exist on each platform but they are different blocks
+            RUNTIME_ITEM_IDS.put("minecraft:grass", RUNTIME_ITEM_IDS.get("minecraft:tallgrass")); // Conflicts with grass block
+            RUNTIME_ITEM_IDS.put("minecraft:map", RUNTIME_ITEM_IDS.get("minecraft:empty_map")); // Conflicts with filled map
+            RUNTIME_ITEM_IDS.put("minecraft:melon", RUNTIME_ITEM_IDS.get("minecraft:melon_block")); // Conflicts with melon slice
+            RUNTIME_ITEM_IDS.put("minecraft:snow", RUNTIME_ITEM_IDS.get("minecraft:snow_layer")); // Conflicts with snow block
+            RUNTIME_ITEM_IDS.put("minecraft:stone_stairs", RUNTIME_ITEM_IDS.get("minecraft:normal_stone_stairs")); // Conflicts with cobblestone stairs
+            RUNTIME_ITEM_IDS.put("minecraft:stonecutter", RUNTIME_ITEM_IDS.get("minecraft:stonecutter_block")); // Conflicts with, surprisingly, the OLD MCPE stonecutter
+
+            // Changed names - the block has a different name on java edition, so we add a new key with the same value. the old bedrock name key stays, with zero use.
+            RUNTIME_ITEM_IDS.put("minecraft:glow_item_frame", RUNTIME_ITEM_IDS.get("minecraft:glow_frame"));
+            RUNTIME_ITEM_IDS.put("minecraft:item_frame", RUNTIME_ITEM_IDS.get("minecraft:frame"));
+            RUNTIME_ITEM_IDS.put("minecraft:oak_door", RUNTIME_ITEM_IDS.get("minecraft:wooden_door"));
+            RUNTIME_ITEM_IDS.put("minecraft:shulker_box", RUNTIME_ITEM_IDS.get("minecraft:undyed_shulker_box"));
+            RUNTIME_ITEM_IDS.put("minecraft:small_dripleaf", RUNTIME_ITEM_IDS.get("minecraft:small_dripleaf_block"));
+            RUNTIME_ITEM_IDS.put("minecraft:waxed_copper_block", RUNTIME_ITEM_IDS.get("minecraft:waxed_copper"));
+
+            // Item replacements - if an item doesn't exist on bedrock edition, we set it to something that does
+            RUNTIME_ITEM_IDS.put("minecraft:globe_banner_pattern", RUNTIME_ITEM_IDS.get("minecraft:banner_pattern"));
+            RUNTIME_ITEM_IDS.put("minecraft:trader_llama_spawn_egg", RUNTIME_ITEM_IDS.get("minecraft:llama_spawn_egg"));
+            RUNTIME_ITEM_IDS.put("minecraft:sculk_sensor", RUNTIME_ITEM_IDS.get("minecraft:info_update")); // soon
+            RUNTIME_ITEM_IDS.put("minecraft:zombified_piglin_spawn_egg", RUNTIME_ITEM_IDS.get("minecraft:zombie_pigman_spawn_egg"));
+
 
             GsonBuilder builder = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping();
             FileWriter writer = new FileWriter(mappings);
@@ -220,6 +230,109 @@ public class MappingsGenerator {
             }
         } catch (IOException ex) {
             ex.printStackTrace();
+        }
+    }
+
+    /**
+     * Create a file to compare the items in the old bedrock item palette vs the current bedrock item palette
+     * @param newRuntimeIds a map of bedrock namespaced id to numerical id
+     * @param oldItemPalette the old bedrock item palette
+     * @throws IOException if there is an exception reading the old palette or writing the diff file
+     */
+    public void createItemDiff(Map<String, Integer> newRuntimeIds, File oldItemPalette) throws IOException {
+        // Set up a blank file
+        File diff = new File("palettes/bedrock_item_diff.txt");
+        if (diff.exists()) {
+            if (!diff.delete()) {
+                System.out.println("Failed to delete an old item diff file (bedrock_item_diff.txt), skipping diff calculation.");
+                return;
+            }
+        }
+        if (!diff.createNewFile()) {
+            System.out.println("Failed to create blank file for diff calculation (bedrock_item_diff.txt).");
+            return;
+        }
+
+        // Get the old palette
+        Type listType = new TypeToken<List<PaletteItemEntry>>() {}.getType();
+        List<PaletteItemEntry> entries = GSON.fromJson(new FileReader(oldItemPalette), listType);
+        Map<String, Integer> oldRuntimeIds = new HashMap<>();
+        entries.forEach(item -> oldRuntimeIds.put(item.getIdentifier(), item.getLegacy_id()));
+
+        // Get the java items, to categorize the diff
+        List<String> javaItems = new ArrayList<>();
+        for (ResourceLocation key : Registry.ITEM.keySet()) {
+            Optional<Item> item = Registry.ITEM.getOptional(key);
+            item.ifPresent( value -> javaItems.add(key.getNamespace() + ":" + key.getPath()));
+        }
+
+        // Create all our categories
+        List<String> sameNameRemovedItems = new ArrayList<>();
+        List<String> differentNameRemovedItems = new ArrayList<>();
+        List<String> sameNameAddedItems = new ArrayList<>();
+        List<String> differentNameAddedItems = new ArrayList<>();
+        List<String> sameNameIdChanges = new ArrayList<>();
+        List<String> differentNameIdChanges = new ArrayList<>();
+        sameNameRemovedItems.add("Bedrock item names that have been removed and are in Java:");
+        differentNameRemovedItems.add("Bedrock item names that have been removed and are not in Java:");
+        sameNameAddedItems.add("Bedrock item names that are new and are in Java:");
+        differentNameAddedItems.add("Bedrock item names that are new and are not in Java:");
+        sameNameIdChanges.add("Bedrock item names that have had their IDs changed, and are in Java:");
+        differentNameIdChanges.add("Bedrock item names have had their IDs changed, and are not in Java:");
+
+        for (String existingName : oldRuntimeIds.keySet()) {
+            if (!newRuntimeIds.containsKey(existingName)) {
+                // Add lines for names that have been removed
+                String entry = "-- " + existingName + " : " + oldRuntimeIds.get(existingName);
+                if (javaItems.contains(existingName)) {
+                    sameNameRemovedItems.add(entry);
+                } else {
+                    differentNameRemovedItems.add(entry);
+                }
+            }
+        }
+        for (String newName : newRuntimeIds.keySet()) {
+            if (!oldRuntimeIds.containsKey(newName)) {
+                // Add lines for names that have been added
+                String entry = "++ " + newName + " : " + newRuntimeIds.get(newName);
+                if (javaItems.contains(newName)) {
+                    sameNameAddedItems.add(entry);
+                } else {
+                    differentNameAddedItems.add(entry);
+                }
+            } else {
+                // Add lines for names that exist in both, but the ID has changed
+                int oldId = oldRuntimeIds.get(newName);
+                int newId = newRuntimeIds.get(newName);
+
+                if (oldId != newId) {
+                    String entry = "|| " + newName + " : " + oldId + " --> " + newId;
+                    if (javaItems.contains(newName)) {
+                        sameNameIdChanges.add(entry);
+                    } else {
+                        differentNameIdChanges.add(entry);
+                    }
+                }
+            }
+        }
+
+        // Combine all the categories
+        List<String> allEntries = new ArrayList<>();
+        allEntries.addAll(sameNameRemovedItems);
+        allEntries.addAll(differentNameRemovedItems);
+        allEntries.addAll(sameNameAddedItems);
+        allEntries.addAll(differentNameAddedItems);
+        allEntries.addAll(sameNameIdChanges);
+        allEntries.addAll(differentNameIdChanges);
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(diff))) {
+            for (String line : allEntries) {
+                writer.write(line);
+                writer.newLine();
+            }
+        } catch (IOException e) {
+            System.out.println("Failed to write bedrock item difference calculation to file:");
+            e.printStackTrace();
         }
     }
 
@@ -575,8 +688,8 @@ public class MappingsGenerator {
                 if (replacementIdentifier != null) {
                     object.addProperty("bedrock_id", RUNTIME_ITEM_IDS.get("minecraft:" + replacementIdentifier));
                 } else {
-                    // Add a sout here if you want to see which java item names aren't in RUNTIME_ITEM_IDS
-                    // Such items exist because the don't have the same name as the bedrock counterpart, and they haven't been added manually to RUNTIME_ITEM_IDS in this file
+                    // print a line here if you want to see which java item names aren't in RUNTIME_ITEM_IDS
+                    // Such items exist because they have a different name, and aren't fixed in generateItems(), so they have only been mapped manually in items.json
                     object.addProperty("bedrock_id", itemEntry.getBedrockId());
                 }
             }

--- a/src/main/java/org/geysermc/generator/MappingsGenerator.java
+++ b/src/main/java/org/geysermc/generator/MappingsGenerator.java
@@ -599,7 +599,7 @@ public class MappingsGenerator {
             object.addProperty("bedrock_data", 0);
         }
         if (object.get("bedrock_id").getAsInt() == 248) {
-            System.out.println("Failed to map " + identifier + " to a bedrock ID other than the update block");
+            System.out.println("Failed to map java item " + identifier + " to a bedrock ID other than the update block (248).");
         }
         if (stackSize != 64) {
             object.addProperty("stack_size", stackSize);


### PR DESCRIPTION
The `old_runtime_item_states.json` I used is from a proxypass with a 1.16.221.01 bedrock server. This doesn't affect generation and is simply a utility.