### PR TITLE
Update mappings to 1.19.70; particularly spawn_eggs

### DIFF
--- a/palettes/runtime_item_states.json
+++ b/palettes/runtime_item_states.json
@@ -1,7 +1,7 @@
 [
     {
         "name" : "minecraft:acacia_boat",
-        "id" : 379
+        "id" : 380
     },
     {
         "name" : "minecraft:acacia_button",
@@ -9,15 +9,19 @@
     },
     {
         "name" : "minecraft:acacia_chest_boat",
-        "id" : 643
+        "id" : 648
     },
     {
         "name" : "minecraft:acacia_door",
-        "id" : 556
+        "id" : 562
     },
     {
         "name" : "minecraft:acacia_fence_gate",
         "id" : 187
+    },
+    {
+        "name" : "minecraft:acacia_hanging_sign",
+        "id" : -504
     },
     {
         "name" : "minecraft:acacia_pressure_plate",
@@ -25,7 +29,7 @@
     },
     {
         "name" : "minecraft:acacia_sign",
-        "id" : 579
+        "id" : 585
     },
     {
         "name" : "minecraft:acacia_stairs",
@@ -49,7 +53,7 @@
     },
     {
         "name" : "minecraft:agent_spawn_egg",
-        "id" : 487
+        "id" : 488
     },
     {
         "name" : "minecraft:air",
@@ -57,7 +61,7 @@
     },
     {
         "name" : "minecraft:allay_spawn_egg",
-        "id" : 631
+        "id" : 637
     },
     {
         "name" : "minecraft:allow",
@@ -73,7 +77,7 @@
     },
     {
         "name" : "minecraft:amethyst_shard",
-        "id" : 624
+        "id" : 630
     },
     {
         "name" : "minecraft:ancient_debris",
@@ -92,20 +96,28 @@
         "id" : 257
     },
     {
+        "name" : "minecraft:archer_pottery_shard",
+        "id" : 659
+    },
+    {
         "name" : "minecraft:armor_stand",
-        "id" : 552
+        "id" : 558
+    },
+    {
+        "name" : "minecraft:arms_up_pottery_shard",
+        "id" : 660
     },
     {
         "name" : "minecraft:arrow",
-        "id" : 301
+        "id" : 302
     },
     {
         "name" : "minecraft:axolotl_bucket",
-        "id" : 369
+        "id" : 370
     },
     {
         "name" : "minecraft:axolotl_spawn_egg",
-        "id" : 500
+        "id" : 502
     },
     {
         "name" : "minecraft:azalea",
@@ -125,23 +137,107 @@
     },
     {
         "name" : "minecraft:balloon",
-        "id" : 598
+        "id" : 604
     },
     {
         "name" : "minecraft:bamboo",
         "id" : -163
     },
     {
+        "name" : "minecraft:bamboo_block",
+        "id" : -527
+    },
+    {
+        "name" : "minecraft:bamboo_button",
+        "id" : -511
+    },
+    {
+        "name" : "minecraft:bamboo_chest_raft",
+        "id" : 657
+    },
+    {
+        "name" : "minecraft:bamboo_door",
+        "id" : -517
+    },
+    {
+        "name" : "minecraft:bamboo_double_slab",
+        "id" : -521
+    },
+    {
+        "name" : "minecraft:bamboo_fence",
+        "id" : -515
+    },
+    {
+        "name" : "minecraft:bamboo_fence_gate",
+        "id" : -516
+    },
+    {
+        "name" : "minecraft:bamboo_hanging_sign",
+        "id" : -522
+    },
+    {
+        "name" : "minecraft:bamboo_mosaic",
+        "id" : -509
+    },
+    {
+        "name" : "minecraft:bamboo_mosaic_double_slab",
+        "id" : -525
+    },
+    {
+        "name" : "minecraft:bamboo_mosaic_slab",
+        "id" : -524
+    },
+    {
+        "name" : "minecraft:bamboo_mosaic_stairs",
+        "id" : -523
+    },
+    {
+        "name" : "minecraft:bamboo_planks",
+        "id" : -510
+    },
+    {
+        "name" : "minecraft:bamboo_pressure_plate",
+        "id" : -514
+    },
+    {
+        "name" : "minecraft:bamboo_raft",
+        "id" : 656
+    },
+    {
         "name" : "minecraft:bamboo_sapling",
         "id" : -164
     },
     {
+        "name" : "minecraft:bamboo_sign",
+        "id" : 655
+    },
+    {
+        "name" : "minecraft:bamboo_slab",
+        "id" : -513
+    },
+    {
+        "name" : "minecraft:bamboo_stairs",
+        "id" : -512
+    },
+    {
+        "name" : "minecraft:bamboo_standing_sign",
+        "id" : -518
+    },
+    {
+        "name" : "minecraft:bamboo_trapdoor",
+        "id" : -520
+    },
+    {
+        "name" : "minecraft:bamboo_wall_sign",
+        "id" : -519
+    },
+    {
         "name" : "minecraft:banner",
-        "id" : 567
+        "id" : 573
     },
     {
         "name" : "minecraft:banner_pattern",
-        "id" : 651
+        "id" : 667
     },
     {
         "name" : "minecraft:barrel",
@@ -157,7 +253,7 @@
     },
     {
         "name" : "minecraft:bat_spawn_egg",
-        "id" : 453
+        "id" : 454
     },
     {
         "name" : "minecraft:beacon",
@@ -165,7 +261,7 @@
     },
     {
         "name" : "minecraft:bed",
-        "id" : 418
+        "id" : 419
     },
     {
         "name" : "minecraft:bedrock",
@@ -177,7 +273,7 @@
     },
     {
         "name" : "minecraft:bee_spawn_egg",
-        "id" : 494
+        "id" : 495
     },
     {
         "name" : "minecraft:beef",
@@ -209,7 +305,7 @@
     },
     {
         "name" : "minecraft:birch_boat",
-        "id" : 376
+        "id" : 377
     },
     {
         "name" : "minecraft:birch_button",
@@ -217,15 +313,19 @@
     },
     {
         "name" : "minecraft:birch_chest_boat",
-        "id" : 640
+        "id" : 645
     },
     {
         "name" : "minecraft:birch_door",
-        "id" : 554
+        "id" : 560
     },
     {
         "name" : "minecraft:birch_fence_gate",
         "id" : 184
+    },
+    {
+        "name" : "minecraft:birch_hanging_sign",
+        "id" : -502
     },
     {
         "name" : "minecraft:birch_pressure_plate",
@@ -233,7 +333,7 @@
     },
     {
         "name" : "minecraft:birch_sign",
-        "id" : 577
+        "id" : 583
     },
     {
         "name" : "minecraft:birch_stairs",
@@ -261,11 +361,15 @@
     },
     {
         "name" : "minecraft:black_dye",
-        "id" : 395
+        "id" : 396
     },
     {
         "name" : "minecraft:black_glazed_terracotta",
         "id" : 235
+    },
+    {
+        "name" : "minecraft:black_wool",
+        "id" : -554
     },
     {
         "name" : "minecraft:blackstone",
@@ -293,19 +397,19 @@
     },
     {
         "name" : "minecraft:blaze_powder",
-        "id" : 429
+        "id" : 430
     },
     {
         "name" : "minecraft:blaze_rod",
-        "id" : 423
+        "id" : 424
     },
     {
         "name" : "minecraft:blaze_spawn_egg",
-        "id" : 456
+        "id" : 457
     },
     {
         "name" : "minecraft:bleach",
-        "id" : 596
+        "id" : 602
     },
     {
         "name" : "minecraft:blue_candle",
@@ -317,7 +421,7 @@
     },
     {
         "name" : "minecraft:blue_dye",
-        "id" : 399
+        "id" : 400
     },
     {
         "name" : "minecraft:blue_glazed_terracotta",
@@ -328,12 +432,16 @@
         "id" : -11
     },
     {
+        "name" : "minecraft:blue_wool",
+        "id" : -563
+    },
+    {
         "name" : "minecraft:boat",
-        "id" : 649
+        "id" : 665
     },
     {
         "name" : "minecraft:bone",
-        "id" : 415
+        "id" : 416
     },
     {
         "name" : "minecraft:bone_block",
@@ -341,11 +449,11 @@
     },
     {
         "name" : "minecraft:bone_meal",
-        "id" : 411
+        "id" : 412
     },
     {
         "name" : "minecraft:book",
-        "id" : 387
+        "id" : 388
     },
     {
         "name" : "minecraft:bookshelf",
@@ -357,15 +465,15 @@
     },
     {
         "name" : "minecraft:bordure_indented_banner_pattern",
-        "id" : 586
+        "id" : 592
     },
     {
         "name" : "minecraft:bow",
-        "id" : 300
+        "id" : 301
     },
     {
         "name" : "minecraft:bowl",
-        "id" : 321
+        "id" : 322
     },
     {
         "name" : "minecraft:bread",
@@ -373,11 +481,11 @@
     },
     {
         "name" : "minecraft:brewing_stand",
-        "id" : 431
+        "id" : 432
     },
     {
         "name" : "minecraft:brick",
-        "id" : 383
+        "id" : 384
     },
     {
         "name" : "minecraft:brick_block",
@@ -397,7 +505,7 @@
     },
     {
         "name" : "minecraft:brown_dye",
-        "id" : 398
+        "id" : 399
     },
     {
         "name" : "minecraft:brown_glazed_terracotta",
@@ -412,12 +520,20 @@
         "id" : 99
     },
     {
+        "name" : "minecraft:brown_wool",
+        "id" : -555
+    },
+    {
+        "name" : "minecraft:brush",
+        "id" : 663
+    },
+    {
         "name" : "minecraft:bubble_column",
         "id" : -160
     },
     {
         "name" : "minecraft:bucket",
-        "id" : 360
+        "id" : 361
     },
     {
         "name" : "minecraft:budding_amethyst",
@@ -429,19 +545,23 @@
     },
     {
         "name" : "minecraft:cake",
-        "id" : 417
+        "id" : 418
     },
     {
         "name" : "minecraft:calcite",
         "id" : -326
     },
     {
+        "name" : "minecraft:camel_spawn_egg",
+        "id" : 658
+    },
+    {
         "name" : "minecraft:camera",
-        "id" : 593
+        "id" : 599
     },
     {
         "name" : "minecraft:campfire",
-        "id" : 589
+        "id" : 595
     },
     {
         "name" : "minecraft:candle",
@@ -461,7 +581,7 @@
     },
     {
         "name" : "minecraft:carrot_on_a_stick",
-        "id" : 517
+        "id" : 523
     },
     {
         "name" : "minecraft:carrots",
@@ -477,15 +597,15 @@
     },
     {
         "name" : "minecraft:cat_spawn_egg",
-        "id" : 488
+        "id" : 489
     },
     {
         "name" : "minecraft:cauldron",
-        "id" : 432
+        "id" : 433
     },
     {
         "name" : "minecraft:cave_spider_spawn_egg",
-        "id" : 457
+        "id" : 458
     },
     {
         "name" : "minecraft:cave_vines",
@@ -501,7 +621,7 @@
     },
     {
         "name" : "minecraft:chain",
-        "id" : 619
+        "id" : 625
     },
     {
         "name" : "minecraft:chain_command_block",
@@ -509,23 +629,23 @@
     },
     {
         "name" : "minecraft:chainmail_boots",
-        "id" : 342
+        "id" : 343
     },
     {
         "name" : "minecraft:chainmail_chestplate",
-        "id" : 340
-    },
-    {
-        "name" : "minecraft:chainmail_helmet",
-        "id" : 339
-    },
-    {
-        "name" : "minecraft:chainmail_leggings",
         "id" : 341
     },
     {
+        "name" : "minecraft:chainmail_helmet",
+        "id" : 340
+    },
+    {
+        "name" : "minecraft:chainmail_leggings",
+        "id" : 342
+    },
+    {
         "name" : "minecraft:charcoal",
-        "id" : 303
+        "id" : 304
     },
     {
         "name" : "minecraft:chemical_heat",
@@ -541,11 +661,11 @@
     },
     {
         "name" : "minecraft:chest_boat",
-        "id" : 646
+        "id" : 651
     },
     {
         "name" : "minecraft:chest_minecart",
-        "id" : 389
+        "id" : 390
     },
     {
         "name" : "minecraft:chicken",
@@ -553,7 +673,11 @@
     },
     {
         "name" : "minecraft:chicken_spawn_egg",
-        "id" : 435
+        "id" : 436
+    },
+    {
+        "name" : "minecraft:chiseled_bookshelf",
+        "id" : -526
     },
     {
         "name" : "minecraft:chiseled_deepslate",
@@ -573,7 +697,7 @@
     },
     {
         "name" : "minecraft:chorus_fruit",
-        "id" : 558
+        "id" : 564
     },
     {
         "name" : "minecraft:chorus_plant",
@@ -585,7 +709,7 @@
     },
     {
         "name" : "minecraft:clay_ball",
-        "id" : 384
+        "id" : 385
     },
     {
         "name" : "minecraft:client_request_placeholder_block",
@@ -593,11 +717,11 @@
     },
     {
         "name" : "minecraft:clock",
-        "id" : 393
+        "id" : 394
     },
     {
         "name" : "minecraft:coal",
-        "id" : 302
+        "id" : 303
     },
     {
         "name" : "minecraft:coal_block",
@@ -641,7 +765,7 @@
     },
     {
         "name" : "minecraft:cocoa_beans",
-        "id" : 412
+        "id" : 413
     },
     {
         "name" : "minecraft:cod",
@@ -649,11 +773,11 @@
     },
     {
         "name" : "minecraft:cod_bucket",
-        "id" : 364
+        "id" : 365
     },
     {
         "name" : "minecraft:cod_spawn_egg",
-        "id" : 480
+        "id" : 481
     },
     {
         "name" : "minecraft:colored_torch_bp",
@@ -669,15 +793,15 @@
     },
     {
         "name" : "minecraft:command_block_minecart",
-        "id" : 563
+        "id" : 569
     },
     {
         "name" : "minecraft:comparator",
-        "id" : 522
+        "id" : 528
     },
     {
         "name" : "minecraft:compass",
-        "id" : 391
+        "id" : 392
     },
     {
         "name" : "minecraft:composter",
@@ -685,7 +809,7 @@
     },
     {
         "name" : "minecraft:compound",
-        "id" : 594
+        "id" : 600
     },
     {
         "name" : "minecraft:concrete",
@@ -713,7 +837,7 @@
     },
     {
         "name" : "minecraft:cooked_mutton",
-        "id" : 551
+        "id" : 557
     },
     {
         "name" : "minecraft:cooked_porkchop",
@@ -737,7 +861,7 @@
     },
     {
         "name" : "minecraft:copper_ingot",
-        "id" : 504
+        "id" : 510
     },
     {
         "name" : "minecraft:copper_ore",
@@ -773,7 +897,7 @@
     },
     {
         "name" : "minecraft:cow_spawn_egg",
-        "id" : 436
+        "id" : 437
     },
     {
         "name" : "minecraft:cracked_deepslate_bricks",
@@ -797,11 +921,11 @@
     },
     {
         "name" : "minecraft:creeper_banner_pattern",
-        "id" : 582
+        "id" : 588
     },
     {
         "name" : "minecraft:creeper_spawn_egg",
-        "id" : 441
+        "id" : 442
     },
     {
         "name" : "minecraft:crimson_button",
@@ -809,7 +933,7 @@
     },
     {
         "name" : "minecraft:crimson_door",
-        "id" : 616
+        "id" : 622
     },
     {
         "name" : "minecraft:crimson_double_slab",
@@ -826,6 +950,10 @@
     {
         "name" : "minecraft:crimson_fungus",
         "id" : -228
+    },
+    {
+        "name" : "minecraft:crimson_hanging_sign",
+        "id" : -506
     },
     {
         "name" : "minecraft:crimson_hyphae",
@@ -849,7 +977,7 @@
     },
     {
         "name" : "minecraft:crimson_sign",
-        "id" : 614
+        "id" : 620
     },
     {
         "name" : "minecraft:crimson_slab",
@@ -877,7 +1005,7 @@
     },
     {
         "name" : "minecraft:crossbow",
-        "id" : 575
+        "id" : 581
     },
     {
         "name" : "minecraft:crying_obsidian",
@@ -905,15 +1033,19 @@
     },
     {
         "name" : "minecraft:cyan_dye",
-        "id" : 401
+        "id" : 402
     },
     {
         "name" : "minecraft:cyan_glazed_terracotta",
         "id" : 229
     },
     {
+        "name" : "minecraft:cyan_wool",
+        "id" : -561
+    },
+    {
         "name" : "minecraft:dark_oak_boat",
-        "id" : 380
+        "id" : 381
     },
     {
         "name" : "minecraft:dark_oak_button",
@@ -921,15 +1053,19 @@
     },
     {
         "name" : "minecraft:dark_oak_chest_boat",
-        "id" : 644
+        "id" : 649
     },
     {
         "name" : "minecraft:dark_oak_door",
-        "id" : 557
+        "id" : 563
     },
     {
         "name" : "minecraft:dark_oak_fence_gate",
         "id" : 186
+    },
+    {
+        "name" : "minecraft:dark_oak_hanging_sign",
+        "id" : -505
     },
     {
         "name" : "minecraft:dark_oak_pressure_plate",
@@ -937,7 +1073,7 @@
     },
     {
         "name" : "minecraft:dark_oak_sign",
-        "id" : 580
+        "id" : 586
     },
     {
         "name" : "minecraft:dark_oak_stairs",
@@ -970,6 +1106,10 @@
     {
         "name" : "minecraft:deadbush",
         "id" : 32
+    },
+    {
+        "name" : "minecraft:decorated_pot",
+        "id" : -551
     },
     {
         "name" : "minecraft:deepslate",
@@ -1057,11 +1197,11 @@
     },
     {
         "name" : "minecraft:diamond",
-        "id" : 304
+        "id" : 305
     },
     {
         "name" : "minecraft:diamond_axe",
-        "id" : 319
+        "id" : 320
     },
     {
         "name" : "minecraft:diamond_block",
@@ -1069,27 +1209,27 @@
     },
     {
         "name" : "minecraft:diamond_boots",
-        "id" : 350
+        "id" : 351
     },
     {
         "name" : "minecraft:diamond_chestplate",
-        "id" : 348
+        "id" : 349
     },
     {
         "name" : "minecraft:diamond_helmet",
-        "id" : 347
+        "id" : 348
     },
     {
         "name" : "minecraft:diamond_hoe",
-        "id" : 332
+        "id" : 333
     },
     {
         "name" : "minecraft:diamond_horse_armor",
-        "id" : 533
+        "id" : 539
     },
     {
         "name" : "minecraft:diamond_leggings",
-        "id" : 349
+        "id" : 350
     },
     {
         "name" : "minecraft:diamond_ore",
@@ -1097,15 +1237,15 @@
     },
     {
         "name" : "minecraft:diamond_pickaxe",
-        "id" : 318
+        "id" : 319
     },
     {
         "name" : "minecraft:diamond_shovel",
-        "id" : 317
+        "id" : 318
     },
     {
         "name" : "minecraft:diamond_sword",
-        "id" : 316
+        "id" : 317
     },
     {
         "name" : "minecraft:diorite_stairs",
@@ -1121,7 +1261,7 @@
     },
     {
         "name" : "minecraft:disc_fragment_5",
-        "id" : 638
+        "id" : 643
     },
     {
         "name" : "minecraft:dispenser",
@@ -1129,11 +1269,11 @@
     },
     {
         "name" : "minecraft:dolphin_spawn_egg",
-        "id" : 484
+        "id" : 485
     },
     {
         "name" : "minecraft:donkey_spawn_egg",
-        "id" : 465
+        "id" : 466
     },
     {
         "name" : "minecraft:double_cut_copper_slab",
@@ -1165,7 +1305,7 @@
     },
     {
         "name" : "minecraft:dragon_breath",
-        "id" : 560
+        "id" : 566
     },
     {
         "name" : "minecraft:dragon_egg",
@@ -1189,23 +1329,23 @@
     },
     {
         "name" : "minecraft:drowned_spawn_egg",
-        "id" : 483
+        "id" : 484
     },
     {
         "name" : "minecraft:dye",
-        "id" : 650
+        "id" : 666
     },
     {
         "name" : "minecraft:echo_shard",
-        "id" : 648
+        "id" : 653
     },
     {
         "name" : "minecraft:egg",
-        "id" : 390
+        "id" : 391
     },
     {
         "name" : "minecraft:elder_guardian_spawn_egg",
-        "id" : 471
+        "id" : 472
     },
     {
         "name" : "minecraft:element_0",
@@ -1685,11 +1825,11 @@
     },
     {
         "name" : "minecraft:elytra",
-        "id" : 564
+        "id" : 570
     },
     {
         "name" : "minecraft:emerald",
-        "id" : 512
+        "id" : 518
     },
     {
         "name" : "minecraft:emerald_block",
@@ -1701,11 +1841,11 @@
     },
     {
         "name" : "minecraft:empty_map",
-        "id" : 515
+        "id" : 521
     },
     {
         "name" : "minecraft:enchanted_book",
-        "id" : 521
+        "id" : 527
     },
     {
         "name" : "minecraft:enchanted_golden_apple",
@@ -1725,7 +1865,7 @@
     },
     {
         "name" : "minecraft:end_crystal",
-        "id" : 653
+        "id" : 669
     },
     {
         "name" : "minecraft:end_gateway",
@@ -1752,28 +1892,32 @@
         "id" : 130
     },
     {
+        "name" : "minecraft:ender_dragon_spawn_egg",
+        "id" : 507
+    },
+    {
         "name" : "minecraft:ender_eye",
-        "id" : 433
+        "id" : 434
     },
     {
         "name" : "minecraft:ender_pearl",
-        "id" : 422
+        "id" : 423
     },
     {
         "name" : "minecraft:enderman_spawn_egg",
-        "id" : 442
+        "id" : 443
     },
     {
         "name" : "minecraft:endermite_spawn_egg",
-        "id" : 460
+        "id" : 461
     },
     {
         "name" : "minecraft:evoker_spawn_egg",
-        "id" : 475
+        "id" : 476
     },
     {
         "name" : "minecraft:experience_bottle",
-        "id" : 508
+        "id" : 514
     },
     {
         "name" : "minecraft:exposed_copper",
@@ -1801,7 +1945,7 @@
     },
     {
         "name" : "minecraft:feather",
-        "id" : 327
+        "id" : 328
     },
     {
         "name" : "minecraft:fence",
@@ -1813,15 +1957,15 @@
     },
     {
         "name" : "minecraft:fermented_spider_eye",
-        "id" : 428
+        "id" : 429
     },
     {
         "name" : "minecraft:field_masoned_banner_pattern",
-        "id" : 585
+        "id" : 591
     },
     {
         "name" : "minecraft:filled_map",
-        "id" : 420
+        "id" : 421
     },
     {
         "name" : "minecraft:fire",
@@ -1829,23 +1973,19 @@
     },
     {
         "name" : "minecraft:fire_charge",
-        "id" : 509
-    },
-    {
-        "name" : "minecraft:firefly_spawn_egg",
-        "id" : 633
+        "id" : 515
     },
     {
         "name" : "minecraft:firework_rocket",
-        "id" : 519
+        "id" : 525
     },
     {
         "name" : "minecraft:firework_star",
-        "id" : 520
+        "id" : 526
     },
     {
         "name" : "minecraft:fishing_rod",
-        "id" : 392
+        "id" : 393
     },
     {
         "name" : "minecraft:fletching_table",
@@ -1853,19 +1993,19 @@
     },
     {
         "name" : "minecraft:flint",
-        "id" : 356
+        "id" : 357
     },
     {
         "name" : "minecraft:flint_and_steel",
-        "id" : 299
+        "id" : 300
     },
     {
         "name" : "minecraft:flower_banner_pattern",
-        "id" : 581
+        "id" : 587
     },
     {
         "name" : "minecraft:flower_pot",
-        "id" : 514
+        "id" : 520
     },
     {
         "name" : "minecraft:flowering_azalea",
@@ -1881,11 +2021,11 @@
     },
     {
         "name" : "minecraft:fox_spawn_egg",
-        "id" : 490
+        "id" : 491
     },
     {
         "name" : "minecraft:frame",
-        "id" : 513
+        "id" : 519
     },
     {
         "name" : "minecraft:frog_spawn",
@@ -1893,7 +2033,7 @@
     },
     {
         "name" : "minecraft:frog_spawn_egg",
-        "id" : 628
+        "id" : 634
     },
     {
         "name" : "minecraft:frosted_ice",
@@ -1905,11 +2045,11 @@
     },
     {
         "name" : "minecraft:ghast_spawn_egg",
-        "id" : 454
+        "id" : 455
     },
     {
         "name" : "minecraft:ghast_tear",
-        "id" : 424
+        "id" : 425
     },
     {
         "name" : "minecraft:gilded_blackstone",
@@ -1921,7 +2061,7 @@
     },
     {
         "name" : "minecraft:glass_bottle",
-        "id" : 427
+        "id" : 428
     },
     {
         "name" : "minecraft:glass_pane",
@@ -1929,23 +2069,23 @@
     },
     {
         "name" : "minecraft:glistering_melon_slice",
-        "id" : 434
+        "id" : 435
     },
     {
         "name" : "minecraft:globe_banner_pattern",
-        "id" : 588
+        "id" : 594
     },
     {
         "name" : "minecraft:glow_berries",
-        "id" : 654
+        "id" : 670
     },
     {
         "name" : "minecraft:glow_frame",
-        "id" : 623
+        "id" : 629
     },
     {
         "name" : "minecraft:glow_ink_sac",
-        "id" : 503
+        "id" : 509
     },
     {
         "name" : "minecraft:glow_lichen",
@@ -1953,11 +2093,11 @@
     },
     {
         "name" : "minecraft:glow_squid_spawn_egg",
-        "id" : 502
+        "id" : 504
     },
     {
         "name" : "minecraft:glow_stick",
-        "id" : 601
+        "id" : 607
     },
     {
         "name" : "minecraft:glowingobsidian",
@@ -1969,15 +2109,15 @@
     },
     {
         "name" : "minecraft:glowstone_dust",
-        "id" : 394
+        "id" : 395
     },
     {
         "name" : "minecraft:goat_horn",
-        "id" : 627
+        "id" : 633
     },
     {
         "name" : "minecraft:goat_spawn_egg",
-        "id" : 501
+        "id" : 503
     },
     {
         "name" : "minecraft:gold_block",
@@ -1985,11 +2125,11 @@
     },
     {
         "name" : "minecraft:gold_ingot",
-        "id" : 306
+        "id" : 307
     },
     {
         "name" : "minecraft:gold_nugget",
-        "id" : 425
+        "id" : 426
     },
     {
         "name" : "minecraft:gold_ore",
@@ -2001,11 +2141,11 @@
     },
     {
         "name" : "minecraft:golden_axe",
-        "id" : 325
+        "id" : 326
     },
     {
         "name" : "minecraft:golden_boots",
-        "id" : 354
+        "id" : 355
     },
     {
         "name" : "minecraft:golden_carrot",
@@ -2013,27 +2153,27 @@
     },
     {
         "name" : "minecraft:golden_chestplate",
-        "id" : 352
-    },
-    {
-        "name" : "minecraft:golden_helmet",
-        "id" : 351
-    },
-    {
-        "name" : "minecraft:golden_hoe",
-        "id" : 333
-    },
-    {
-        "name" : "minecraft:golden_horse_armor",
-        "id" : 532
-    },
-    {
-        "name" : "minecraft:golden_leggings",
         "id" : 353
     },
     {
+        "name" : "minecraft:golden_helmet",
+        "id" : 352
+    },
+    {
+        "name" : "minecraft:golden_hoe",
+        "id" : 334
+    },
+    {
+        "name" : "minecraft:golden_horse_armor",
+        "id" : 538
+    },
+    {
+        "name" : "minecraft:golden_leggings",
+        "id" : 354
+    },
+    {
         "name" : "minecraft:golden_pickaxe",
-        "id" : 324
+        "id" : 325
     },
     {
         "name" : "minecraft:golden_rail",
@@ -2041,11 +2181,11 @@
     },
     {
         "name" : "minecraft:golden_shovel",
-        "id" : 323
+        "id" : 324
     },
     {
         "name" : "minecraft:golden_sword",
-        "id" : 322
+        "id" : 323
     },
     {
         "name" : "minecraft:granite_stairs",
@@ -2073,11 +2213,15 @@
     },
     {
         "name" : "minecraft:gray_dye",
-        "id" : 403
+        "id" : 404
     },
     {
         "name" : "minecraft:gray_glazed_terracotta",
         "id" : 227
+    },
+    {
+        "name" : "minecraft:gray_wool",
+        "id" : -553
     },
     {
         "name" : "minecraft:green_candle",
@@ -2089,11 +2233,15 @@
     },
     {
         "name" : "minecraft:green_dye",
-        "id" : 397
+        "id" : 398
     },
     {
         "name" : "minecraft:green_glazed_terracotta",
         "id" : 233
+    },
+    {
+        "name" : "minecraft:green_wool",
+        "id" : -560
     },
     {
         "name" : "minecraft:grindstone",
@@ -2101,11 +2249,11 @@
     },
     {
         "name" : "minecraft:guardian_spawn_egg",
-        "id" : 461
+        "id" : 462
     },
     {
         "name" : "minecraft:gunpowder",
-        "id" : 328
+        "id" : 329
     },
     {
         "name" : "minecraft:hanging_roots",
@@ -2137,7 +2285,7 @@
     },
     {
         "name" : "minecraft:heart_of_the_sea",
-        "id" : 571
+        "id" : 577
     },
     {
         "name" : "minecraft:heavy_weighted_pressure_plate",
@@ -2145,7 +2293,7 @@
     },
     {
         "name" : "minecraft:hoglin_spawn_egg",
-        "id" : 496
+        "id" : 497
     },
     {
         "name" : "minecraft:honey_block",
@@ -2153,11 +2301,11 @@
     },
     {
         "name" : "minecraft:honey_bottle",
-        "id" : 592
+        "id" : 598
     },
     {
         "name" : "minecraft:honeycomb",
-        "id" : 591
+        "id" : 597
     },
     {
         "name" : "minecraft:honeycomb_block",
@@ -2165,19 +2313,19 @@
     },
     {
         "name" : "minecraft:hopper",
-        "id" : 527
+        "id" : 533
     },
     {
         "name" : "minecraft:hopper_minecart",
-        "id" : 526
+        "id" : 532
     },
     {
         "name" : "minecraft:horse_spawn_egg",
-        "id" : 458
+        "id" : 459
     },
     {
         "name" : "minecraft:husk_spawn_egg",
-        "id" : 463
+        "id" : 464
     },
     {
         "name" : "minecraft:ice",
@@ -2185,7 +2333,7 @@
     },
     {
         "name" : "minecraft:ice_bomb",
-        "id" : 595
+        "id" : 601
     },
     {
         "name" : "minecraft:infested_deepslate",
@@ -2201,7 +2349,7 @@
     },
     {
         "name" : "minecraft:ink_sac",
-        "id" : 413
+        "id" : 414
     },
     {
         "name" : "minecraft:invisible_bedrock",
@@ -2209,7 +2357,7 @@
     },
     {
         "name" : "minecraft:iron_axe",
-        "id" : 298
+        "id" : 299
     },
     {
         "name" : "minecraft:iron_bars",
@@ -2221,39 +2369,43 @@
     },
     {
         "name" : "minecraft:iron_boots",
-        "id" : 346
+        "id" : 347
     },
     {
         "name" : "minecraft:iron_chestplate",
-        "id" : 344
-    },
-    {
-        "name" : "minecraft:iron_door",
-        "id" : 372
-    },
-    {
-        "name" : "minecraft:iron_helmet",
-        "id" : 343
-    },
-    {
-        "name" : "minecraft:iron_hoe",
-        "id" : 331
-    },
-    {
-        "name" : "minecraft:iron_horse_armor",
-        "id" : 531
-    },
-    {
-        "name" : "minecraft:iron_ingot",
-        "id" : 305
-    },
-    {
-        "name" : "minecraft:iron_leggings",
         "id" : 345
     },
     {
+        "name" : "minecraft:iron_door",
+        "id" : 373
+    },
+    {
+        "name" : "minecraft:iron_golem_spawn_egg",
+        "id" : 505
+    },
+    {
+        "name" : "minecraft:iron_helmet",
+        "id" : 344
+    },
+    {
+        "name" : "minecraft:iron_hoe",
+        "id" : 332
+    },
+    {
+        "name" : "minecraft:iron_horse_armor",
+        "id" : 537
+    },
+    {
+        "name" : "minecraft:iron_ingot",
+        "id" : 306
+    },
+    {
+        "name" : "minecraft:iron_leggings",
+        "id" : 346
+    },
+    {
         "name" : "minecraft:iron_nugget",
-        "id" : 569
+        "id" : 575
     },
     {
         "name" : "minecraft:iron_ore",
@@ -2261,15 +2413,15 @@
     },
     {
         "name" : "minecraft:iron_pickaxe",
-        "id" : 297
+        "id" : 298
     },
     {
         "name" : "minecraft:iron_shovel",
-        "id" : 296
+        "id" : 297
     },
     {
         "name" : "minecraft:iron_sword",
-        "id" : 307
+        "id" : 308
     },
     {
         "name" : "minecraft:iron_trapdoor",
@@ -2401,7 +2553,7 @@
     },
     {
         "name" : "minecraft:jungle_boat",
-        "id" : 377
+        "id" : 378
     },
     {
         "name" : "minecraft:jungle_button",
@@ -2409,15 +2561,19 @@
     },
     {
         "name" : "minecraft:jungle_chest_boat",
-        "id" : 641
+        "id" : 646
     },
     {
         "name" : "minecraft:jungle_door",
-        "id" : 555
+        "id" : 561
     },
     {
         "name" : "minecraft:jungle_fence_gate",
         "id" : 185
+    },
+    {
+        "name" : "minecraft:jungle_hanging_sign",
+        "id" : -503
     },
     {
         "name" : "minecraft:jungle_pressure_plate",
@@ -2425,7 +2581,7 @@
     },
     {
         "name" : "minecraft:jungle_sign",
-        "id" : 578
+        "id" : 584
     },
     {
         "name" : "minecraft:jungle_stairs",
@@ -2445,7 +2601,7 @@
     },
     {
         "name" : "minecraft:kelp",
-        "id" : 382
+        "id" : 383
     },
     {
         "name" : "minecraft:ladder",
@@ -2461,7 +2617,7 @@
     },
     {
         "name" : "minecraft:lapis_lazuli",
-        "id" : 414
+        "id" : 415
     },
     {
         "name" : "minecraft:lapis_ore",
@@ -2477,7 +2633,7 @@
     },
     {
         "name" : "minecraft:lava_bucket",
-        "id" : 363
+        "id" : 364
     },
     {
         "name" : "minecraft:lava_cauldron",
@@ -2485,31 +2641,31 @@
     },
     {
         "name" : "minecraft:lead",
-        "id" : 547
+        "id" : 553
     },
     {
         "name" : "minecraft:leather",
-        "id" : 381
+        "id" : 382
     },
     {
         "name" : "minecraft:leather_boots",
-        "id" : 338
+        "id" : 339
     },
     {
         "name" : "minecraft:leather_chestplate",
-        "id" : 336
+        "id" : 337
     },
     {
         "name" : "minecraft:leather_helmet",
-        "id" : 335
+        "id" : 336
     },
     {
         "name" : "minecraft:leather_horse_armor",
-        "id" : 530
+        "id" : 536
     },
     {
         "name" : "minecraft:leather_leggings",
-        "id" : 337
+        "id" : 338
     },
     {
         "name" : "minecraft:leaves",
@@ -2541,11 +2697,15 @@
     },
     {
         "name" : "minecraft:light_blue_dye",
-        "id" : 407
+        "id" : 408
     },
     {
         "name" : "minecraft:light_blue_glazed_terracotta",
         "id" : 223
+    },
+    {
+        "name" : "minecraft:light_blue_wool",
+        "id" : -562
     },
     {
         "name" : "minecraft:light_gray_candle",
@@ -2557,7 +2717,11 @@
     },
     {
         "name" : "minecraft:light_gray_dye",
-        "id" : 402
+        "id" : 403
+    },
+    {
+        "name" : "minecraft:light_gray_wool",
+        "id" : -552
     },
     {
         "name" : "minecraft:light_weighted_pressure_plate",
@@ -2577,15 +2741,19 @@
     },
     {
         "name" : "minecraft:lime_dye",
-        "id" : 405
+        "id" : 406
     },
     {
         "name" : "minecraft:lime_glazed_terracotta",
         "id" : 225
     },
     {
+        "name" : "minecraft:lime_wool",
+        "id" : -559
+    },
+    {
         "name" : "minecraft:lingering_potion",
-        "id" : 562
+        "id" : 568
     },
     {
         "name" : "minecraft:lit_blast_furnace",
@@ -2617,7 +2785,7 @@
     },
     {
         "name" : "minecraft:llama_spawn_egg",
-        "id" : 473
+        "id" : 474
     },
     {
         "name" : "minecraft:lodestone",
@@ -2625,7 +2793,7 @@
     },
     {
         "name" : "minecraft:lodestone_compass",
-        "id" : 602
+        "id" : 608
     },
     {
         "name" : "minecraft:log",
@@ -2649,11 +2817,15 @@
     },
     {
         "name" : "minecraft:magenta_dye",
-        "id" : 408
+        "id" : 409
     },
     {
         "name" : "minecraft:magenta_glazed_terracotta",
         "id" : 222
+    },
+    {
+        "name" : "minecraft:magenta_wool",
+        "id" : -565
     },
     {
         "name" : "minecraft:magma",
@@ -2661,15 +2833,15 @@
     },
     {
         "name" : "minecraft:magma_cream",
-        "id" : 430
+        "id" : 431
     },
     {
         "name" : "minecraft:magma_cube_spawn_egg",
-        "id" : 455
+        "id" : 456
     },
     {
         "name" : "minecraft:mangrove_boat",
-        "id" : 636
+        "id" : 641
     },
     {
         "name" : "minecraft:mangrove_button",
@@ -2677,11 +2849,11 @@
     },
     {
         "name" : "minecraft:mangrove_chest_boat",
-        "id" : 645
+        "id" : 650
     },
     {
         "name" : "minecraft:mangrove_door",
-        "id" : 634
+        "id" : 639
     },
     {
         "name" : "minecraft:mangrove_double_slab",
@@ -2694,6 +2866,10 @@
     {
         "name" : "minecraft:mangrove_fence_gate",
         "id" : -492
+    },
+    {
+        "name" : "minecraft:mangrove_hanging_sign",
+        "id" : -508
     },
     {
         "name" : "minecraft:mangrove_leaves",
@@ -2721,7 +2897,7 @@
     },
     {
         "name" : "minecraft:mangrove_sign",
-        "id" : 635
+        "id" : 640
     },
     {
         "name" : "minecraft:mangrove_slab",
@@ -2749,7 +2925,7 @@
     },
     {
         "name" : "minecraft:medicine",
-        "id" : 599
+        "id" : 605
     },
     {
         "name" : "minecraft:medium_amethyst_bud",
@@ -2773,11 +2949,11 @@
     },
     {
         "name" : "minecraft:milk_bucket",
-        "id" : 361
+        "id" : 362
     },
     {
         "name" : "minecraft:minecart",
-        "id" : 370
+        "id" : 371
     },
     {
         "name" : "minecraft:mob_spawner",
@@ -2785,7 +2961,7 @@
     },
     {
         "name" : "minecraft:mojang_banner_pattern",
-        "id" : 584
+        "id" : 590
     },
     {
         "name" : "minecraft:monster_egg",
@@ -2793,7 +2969,7 @@
     },
     {
         "name" : "minecraft:mooshroom_spawn_egg",
-        "id" : 440
+        "id" : 441
     },
     {
         "name" : "minecraft:moss_block",
@@ -2849,7 +3025,7 @@
     },
     {
         "name" : "minecraft:mule_spawn_egg",
-        "id" : 466
+        "id" : 467
     },
     {
         "name" : "minecraft:mushroom_stew",
@@ -2857,67 +3033,67 @@
     },
     {
         "name" : "minecraft:music_disc_11",
-        "id" : 544
+        "id" : 550
     },
     {
         "name" : "minecraft:music_disc_13",
-        "id" : 534
-    },
-    {
-        "name" : "minecraft:music_disc_5",
-        "id" : 637
-    },
-    {
-        "name" : "minecraft:music_disc_blocks",
-        "id" : 536
-    },
-    {
-        "name" : "minecraft:music_disc_cat",
-        "id" : 535
-    },
-    {
-        "name" : "minecraft:music_disc_chirp",
-        "id" : 537
-    },
-    {
-        "name" : "minecraft:music_disc_far",
-        "id" : 538
-    },
-    {
-        "name" : "minecraft:music_disc_mall",
-        "id" : 539
-    },
-    {
-        "name" : "minecraft:music_disc_mellohi",
         "id" : 540
     },
     {
-        "name" : "minecraft:music_disc_otherside",
-        "id" : 626
+        "name" : "minecraft:music_disc_5",
+        "id" : 642
     },
     {
-        "name" : "minecraft:music_disc_pigstep",
-        "id" : 620
-    },
-    {
-        "name" : "minecraft:music_disc_stal",
-        "id" : 541
-    },
-    {
-        "name" : "minecraft:music_disc_strad",
+        "name" : "minecraft:music_disc_blocks",
         "id" : 542
     },
     {
-        "name" : "minecraft:music_disc_wait",
-        "id" : 545
+        "name" : "minecraft:music_disc_cat",
+        "id" : 541
     },
     {
-        "name" : "minecraft:music_disc_ward",
+        "name" : "minecraft:music_disc_chirp",
         "id" : 543
     },
     {
+        "name" : "minecraft:music_disc_far",
+        "id" : 544
+    },
+    {
+        "name" : "minecraft:music_disc_mall",
+        "id" : 545
+    },
+    {
+        "name" : "minecraft:music_disc_mellohi",
+        "id" : 546
+    },
+    {
+        "name" : "minecraft:music_disc_otherside",
+        "id" : 632
+    },
+    {
+        "name" : "minecraft:music_disc_pigstep",
+        "id" : 626
+    },
+    {
+        "name" : "minecraft:music_disc_stal",
+        "id" : 547
+    },
+    {
+        "name" : "minecraft:music_disc_strad",
+        "id" : 548
+    },
+    {
+        "name" : "minecraft:music_disc_wait",
+        "id" : 551
+    },
+    {
+        "name" : "minecraft:music_disc_ward",
+        "id" : 549
+    },
+    {
         "name" : "minecraft:mutton",
-        "id" : 550
+        "id" : 556
     },
     {
         "name" : "minecraft:mycelium",
@@ -2925,11 +3101,11 @@
     },
     {
         "name" : "minecraft:name_tag",
-        "id" : 548
+        "id" : 554
     },
     {
         "name" : "minecraft:nautilus_shell",
-        "id" : 570
+        "id" : 576
     },
     {
         "name" : "minecraft:nether_brick",
@@ -2949,11 +3125,11 @@
     },
     {
         "name" : "minecraft:nether_sprouts",
-        "id" : 621
+        "id" : 627
     },
     {
         "name" : "minecraft:nether_star",
-        "id" : 518
+        "id" : 524
     },
     {
         "name" : "minecraft:nether_wart",
@@ -2965,11 +3141,11 @@
     },
     {
         "name" : "minecraft:netherbrick",
-        "id" : 523
+        "id" : 529
     },
     {
         "name" : "minecraft:netherite_axe",
-        "id" : 607
+        "id" : 613
     },
     {
         "name" : "minecraft:netherite_block",
@@ -2977,43 +3153,43 @@
     },
     {
         "name" : "minecraft:netherite_boots",
-        "id" : 612
+        "id" : 618
     },
     {
         "name" : "minecraft:netherite_chestplate",
-        "id" : 610
+        "id" : 616
     },
     {
         "name" : "minecraft:netherite_helmet",
-        "id" : 609
+        "id" : 615
     },
     {
         "name" : "minecraft:netherite_hoe",
-        "id" : 608
+        "id" : 614
     },
     {
         "name" : "minecraft:netherite_ingot",
-        "id" : 603
+        "id" : 609
     },
     {
         "name" : "minecraft:netherite_leggings",
-        "id" : 611
+        "id" : 617
     },
     {
         "name" : "minecraft:netherite_pickaxe",
-        "id" : 606
+        "id" : 612
     },
     {
         "name" : "minecraft:netherite_scrap",
-        "id" : 613
+        "id" : 619
     },
     {
         "name" : "minecraft:netherite_shovel",
-        "id" : 605
+        "id" : 611
     },
     {
         "name" : "minecraft:netherite_sword",
-        "id" : 604
+        "id" : 610
     },
     {
         "name" : "minecraft:netherrack",
@@ -3033,19 +3209,23 @@
     },
     {
         "name" : "minecraft:npc_spawn_egg",
-        "id" : 470
+        "id" : 471
     },
     {
         "name" : "minecraft:oak_boat",
-        "id" : 375
+        "id" : 376
     },
     {
         "name" : "minecraft:oak_chest_boat",
-        "id" : 639
+        "id" : 644
+    },
+    {
+        "name" : "minecraft:oak_hanging_sign",
+        "id" : -500
     },
     {
         "name" : "minecraft:oak_sign",
-        "id" : 358
+        "id" : 359
     },
     {
         "name" : "minecraft:oak_stairs",
@@ -3061,7 +3241,7 @@
     },
     {
         "name" : "minecraft:ocelot_spawn_egg",
-        "id" : 451
+        "id" : 452
     },
     {
         "name" : "minecraft:ochre_froglight",
@@ -3077,11 +3257,15 @@
     },
     {
         "name" : "minecraft:orange_dye",
-        "id" : 409
+        "id" : 410
     },
     {
         "name" : "minecraft:orange_glazed_terracotta",
         "id" : 221
+    },
+    {
+        "name" : "minecraft:orange_wool",
+        "id" : -557
     },
     {
         "name" : "minecraft:oxidized_copper",
@@ -3113,19 +3297,19 @@
     },
     {
         "name" : "minecraft:painting",
-        "id" : 357
+        "id" : 358
     },
     {
         "name" : "minecraft:panda_spawn_egg",
-        "id" : 489
+        "id" : 490
     },
     {
         "name" : "minecraft:paper",
-        "id" : 386
+        "id" : 387
     },
     {
         "name" : "minecraft:parrot_spawn_egg",
-        "id" : 478
+        "id" : 479
     },
     {
         "name" : "minecraft:pearlescent_froglight",
@@ -3133,31 +3317,31 @@
     },
     {
         "name" : "minecraft:phantom_membrane",
-        "id" : 574
+        "id" : 580
     },
     {
         "name" : "minecraft:phantom_spawn_egg",
-        "id" : 486
+        "id" : 487
     },
     {
         "name" : "minecraft:pig_spawn_egg",
-        "id" : 437
+        "id" : 438
     },
     {
         "name" : "minecraft:piglin_banner_pattern",
-        "id" : 587
+        "id" : 593
     },
     {
         "name" : "minecraft:piglin_brute_spawn_egg",
-        "id" : 499
+        "id" : 500
     },
     {
         "name" : "minecraft:piglin_spawn_egg",
-        "id" : 497
+        "id" : 498
     },
     {
         "name" : "minecraft:pillager_spawn_egg",
-        "id" : 491
+        "id" : 492
     },
     {
         "name" : "minecraft:pink_candle",
@@ -3169,11 +3353,15 @@
     },
     {
         "name" : "minecraft:pink_dye",
-        "id" : 404
+        "id" : 405
     },
     {
         "name" : "minecraft:pink_glazed_terracotta",
         "id" : 226
+    },
+    {
+        "name" : "minecraft:pink_wool",
+        "id" : -566
     },
     {
         "name" : "minecraft:piston",
@@ -3201,7 +3389,7 @@
     },
     {
         "name" : "minecraft:polar_bear_spawn_egg",
-        "id" : 472
+        "id" : 473
     },
     {
         "name" : "minecraft:polished_andesite_stairs",
@@ -3289,7 +3477,7 @@
     },
     {
         "name" : "minecraft:popped_chorus_fruit",
-        "id" : 559
+        "id" : 565
     },
     {
         "name" : "minecraft:porkchop",
@@ -3309,7 +3497,7 @@
     },
     {
         "name" : "minecraft:potion",
-        "id" : 426
+        "id" : 427
     },
     {
         "name" : "minecraft:powder_snow",
@@ -3317,7 +3505,7 @@
     },
     {
         "name" : "minecraft:powder_snow_bucket",
-        "id" : 368
+        "id" : 369
     },
     {
         "name" : "minecraft:powered_comparator",
@@ -3337,15 +3525,19 @@
     },
     {
         "name" : "minecraft:prismarine_crystals",
-        "id" : 549
+        "id" : 555
     },
     {
         "name" : "minecraft:prismarine_shard",
-        "id" : 565
+        "id" : 571
     },
     {
         "name" : "minecraft:prismarine_stairs",
         "id" : -2
+    },
+    {
+        "name" : "minecraft:prize_pottery_shard",
+        "id" : 661
     },
     {
         "name" : "minecraft:pufferfish",
@@ -3353,11 +3545,11 @@
     },
     {
         "name" : "minecraft:pufferfish_bucket",
-        "id" : 367
+        "id" : 368
     },
     {
         "name" : "minecraft:pufferfish_spawn_egg",
-        "id" : 481
+        "id" : 482
     },
     {
         "name" : "minecraft:pumpkin",
@@ -3385,11 +3577,15 @@
     },
     {
         "name" : "minecraft:purple_dye",
-        "id" : 400
+        "id" : 401
     },
     {
         "name" : "minecraft:purple_glazed_terracotta",
         "id" : 219
+    },
+    {
+        "name" : "minecraft:purple_wool",
+        "id" : -564
     },
     {
         "name" : "minecraft:purpur_block",
@@ -3401,7 +3597,7 @@
     },
     {
         "name" : "minecraft:quartz",
-        "id" : 524
+        "id" : 530
     },
     {
         "name" : "minecraft:quartz_block",
@@ -3425,15 +3621,15 @@
     },
     {
         "name" : "minecraft:rabbit_foot",
-        "id" : 528
+        "id" : 534
     },
     {
         "name" : "minecraft:rabbit_hide",
-        "id" : 529
+        "id" : 535
     },
     {
         "name" : "minecraft:rabbit_spawn_egg",
-        "id" : 459
+        "id" : 460
     },
     {
         "name" : "minecraft:rabbit_stew",
@@ -3445,15 +3641,15 @@
     },
     {
         "name" : "minecraft:rapid_fertilizer",
-        "id" : 597
+        "id" : 603
     },
     {
         "name" : "minecraft:ravager_spawn_egg",
-        "id" : 493
+        "id" : 494
     },
     {
         "name" : "minecraft:raw_copper",
-        "id" : 507
+        "id" : 513
     },
     {
         "name" : "minecraft:raw_copper_block",
@@ -3461,7 +3657,7 @@
     },
     {
         "name" : "minecraft:raw_gold",
-        "id" : 506
+        "id" : 512
     },
     {
         "name" : "minecraft:raw_gold_block",
@@ -3469,7 +3665,7 @@
     },
     {
         "name" : "minecraft:raw_iron",
-        "id" : 505
+        "id" : 511
     },
     {
         "name" : "minecraft:raw_iron_block",
@@ -3477,7 +3673,7 @@
     },
     {
         "name" : "minecraft:recovery_compass",
-        "id" : 647
+        "id" : 652
     },
     {
         "name" : "minecraft:red_candle",
@@ -3489,7 +3685,7 @@
     },
     {
         "name" : "minecraft:red_dye",
-        "id" : 396
+        "id" : 397
     },
     {
         "name" : "minecraft:red_flower",
@@ -3524,8 +3720,12 @@
         "id" : 180
     },
     {
+        "name" : "minecraft:red_wool",
+        "id" : -556
+    },
+    {
         "name" : "minecraft:redstone",
-        "id" : 373
+        "id" : 374
     },
     {
         "name" : "minecraft:redstone_block",
@@ -3553,7 +3753,7 @@
     },
     {
         "name" : "minecraft:repeater",
-        "id" : 419
+        "id" : 420
     },
     {
         "name" : "minecraft:repeating_command_block",
@@ -3573,7 +3773,7 @@
     },
     {
         "name" : "minecraft:saddle",
-        "id" : 371
+        "id" : 372
     },
     {
         "name" : "minecraft:salmon",
@@ -3581,11 +3781,11 @@
     },
     {
         "name" : "minecraft:salmon_bucket",
-        "id" : 365
+        "id" : 366
     },
     {
         "name" : "minecraft:salmon_spawn_egg",
-        "id" : 482
+        "id" : 483
     },
     {
         "name" : "minecraft:sand",
@@ -3629,7 +3829,7 @@
     },
     {
         "name" : "minecraft:scute",
-        "id" : 572
+        "id" : 578
     },
     {
         "name" : "minecraft:sea_lantern",
@@ -3645,15 +3845,15 @@
     },
     {
         "name" : "minecraft:shears",
-        "id" : 421
+        "id" : 422
     },
     {
         "name" : "minecraft:sheep_spawn_egg",
-        "id" : 438
+        "id" : 439
     },
     {
         "name" : "minecraft:shield",
-        "id" : 355
+        "id" : 356
     },
     {
         "name" : "minecraft:shroomlight",
@@ -3665,11 +3865,11 @@
     },
     {
         "name" : "minecraft:shulker_shell",
-        "id" : 566
+        "id" : 572
     },
     {
         "name" : "minecraft:shulker_spawn_egg",
-        "id" : 469
+        "id" : 470
     },
     {
         "name" : "minecraft:silver_glazed_terracotta",
@@ -3677,23 +3877,27 @@
     },
     {
         "name" : "minecraft:silverfish_spawn_egg",
-        "id" : 443
-    },
-    {
-        "name" : "minecraft:skeleton_horse_spawn_egg",
-        "id" : 467
-    },
-    {
-        "name" : "minecraft:skeleton_spawn_egg",
         "id" : 444
     },
     {
+        "name" : "minecraft:skeleton_horse_spawn_egg",
+        "id" : 468
+    },
+    {
+        "name" : "minecraft:skeleton_spawn_egg",
+        "id" : 445
+    },
+    {
         "name" : "minecraft:skull",
-        "id" : 516
+        "id" : 522
     },
     {
         "name" : "minecraft:skull_banner_pattern",
-        "id" : 583
+        "id" : 589
+    },
+    {
+        "name" : "minecraft:skull_pottery_shard",
+        "id" : 662
     },
     {
         "name" : "minecraft:slime",
@@ -3701,11 +3905,11 @@
     },
     {
         "name" : "minecraft:slime_ball",
-        "id" : 388
+        "id" : 389
     },
     {
         "name" : "minecraft:slime_spawn_egg",
-        "id" : 445
+        "id" : 446
     },
     {
         "name" : "minecraft:small_amethyst_bud",
@@ -3744,8 +3948,16 @@
         "id" : -183
     },
     {
+        "name" : "minecraft:sniffer_spawn_egg",
+        "id" : 501
+    },
+    {
         "name" : "minecraft:snow",
         "id" : 80
+    },
+    {
+        "name" : "minecraft:snow_golem_spawn_egg",
+        "id" : 506
     },
     {
         "name" : "minecraft:snow_layer",
@@ -3753,11 +3965,11 @@
     },
     {
         "name" : "minecraft:snowball",
-        "id" : 374
+        "id" : 375
     },
     {
         "name" : "minecraft:soul_campfire",
-        "id" : 622
+        "id" : 628
     },
     {
         "name" : "minecraft:soul_fire",
@@ -3781,11 +3993,11 @@
     },
     {
         "name" : "minecraft:sparkler",
-        "id" : 600
+        "id" : 606
     },
     {
         "name" : "minecraft:spawn_egg",
-        "id" : 652
+        "id" : 668
     },
     {
         "name" : "minecraft:spider_eye",
@@ -3793,11 +4005,11 @@
     },
     {
         "name" : "minecraft:spider_spawn_egg",
-        "id" : 446
+        "id" : 447
     },
     {
         "name" : "minecraft:splash_potion",
-        "id" : 561
+        "id" : 567
     },
     {
         "name" : "minecraft:sponge",
@@ -3809,7 +4021,7 @@
     },
     {
         "name" : "minecraft:spruce_boat",
-        "id" : 378
+        "id" : 379
     },
     {
         "name" : "minecraft:spruce_button",
@@ -3817,15 +4029,19 @@
     },
     {
         "name" : "minecraft:spruce_chest_boat",
-        "id" : 642
+        "id" : 647
     },
     {
         "name" : "minecraft:spruce_door",
-        "id" : 553
+        "id" : 559
     },
     {
         "name" : "minecraft:spruce_fence_gate",
         "id" : 183
+    },
+    {
+        "name" : "minecraft:spruce_hanging_sign",
+        "id" : -501
     },
     {
         "name" : "minecraft:spruce_pressure_plate",
@@ -3833,7 +4049,7 @@
     },
     {
         "name" : "minecraft:spruce_sign",
-        "id" : 576
+        "id" : 582
     },
     {
         "name" : "minecraft:spruce_stairs",
@@ -3853,11 +4069,11 @@
     },
     {
         "name" : "minecraft:spyglass",
-        "id" : 625
+        "id" : 631
     },
     {
         "name" : "minecraft:squid_spawn_egg",
-        "id" : 450
+        "id" : 451
     },
     {
         "name" : "minecraft:stained_glass",
@@ -3881,7 +4097,7 @@
     },
     {
         "name" : "minecraft:stick",
-        "id" : 320
+        "id" : 321
     },
     {
         "name" : "minecraft:sticky_piston",
@@ -3897,7 +4113,7 @@
     },
     {
         "name" : "minecraft:stone_axe",
-        "id" : 315
+        "id" : 316
     },
     {
         "name" : "minecraft:stone_block_slab",
@@ -3925,11 +4141,11 @@
     },
     {
         "name" : "minecraft:stone_hoe",
-        "id" : 330
+        "id" : 331
     },
     {
         "name" : "minecraft:stone_pickaxe",
-        "id" : 314
+        "id" : 315
     },
     {
         "name" : "minecraft:stone_pressure_plate",
@@ -3937,7 +4153,7 @@
     },
     {
         "name" : "minecraft:stone_shovel",
-        "id" : 313
+        "id" : 314
     },
     {
         "name" : "minecraft:stone_stairs",
@@ -3945,7 +4161,7 @@
     },
     {
         "name" : "minecraft:stone_sword",
-        "id" : 312
+        "id" : 313
     },
     {
         "name" : "minecraft:stonebrick",
@@ -3961,19 +4177,23 @@
     },
     {
         "name" : "minecraft:stray_spawn_egg",
-        "id" : 462
+        "id" : 463
     },
     {
         "name" : "minecraft:strider_spawn_egg",
-        "id" : 495
+        "id" : 496
     },
     {
         "name" : "minecraft:string",
-        "id" : 326
+        "id" : 327
     },
     {
         "name" : "minecraft:stripped_acacia_log",
         "id" : -8
+    },
+    {
+        "name" : "minecraft:stripped_bamboo_block",
+        "id" : -528
     },
     {
         "name" : "minecraft:stripped_birch_log",
@@ -4029,15 +4249,19 @@
     },
     {
         "name" : "minecraft:sugar",
-        "id" : 416
+        "id" : 417
     },
     {
         "name" : "minecraft:sugar_cane",
-        "id" : 385
+        "id" : 386
+    },
+    {
+        "name" : "minecraft:suspicious_sand",
+        "id" : -529
     },
     {
         "name" : "minecraft:suspicious_stew",
-        "id" : 590
+        "id" : 596
     },
     {
         "name" : "minecraft:sweet_berries",
@@ -4049,11 +4273,11 @@
     },
     {
         "name" : "minecraft:tadpole_bucket",
-        "id" : 630
+        "id" : 636
     },
     {
         "name" : "minecraft:tadpole_spawn_egg",
-        "id" : 629
+        "id" : 635
     },
     {
         "name" : "minecraft:tallgrass",
@@ -4073,15 +4297,31 @@
     },
     {
         "name" : "minecraft:tnt_minecart",
-        "id" : 525
+        "id" : 531
     },
     {
         "name" : "minecraft:torch",
         "id" : 50
     },
     {
+        "name" : "minecraft:torchflower",
+        "id" : -568
+    },
+    {
+        "name" : "minecraft:torchflower_crop",
+        "id" : -567
+    },
+    {
+        "name" : "minecraft:torchflower_seeds",
+        "id" : 296
+    },
+    {
         "name" : "minecraft:totem_of_undying",
-        "id" : 568
+        "id" : 574
+    },
+    {
+        "name" : "minecraft:trader_llama_spawn_egg",
+        "id" : 654
     },
     {
         "name" : "minecraft:trapdoor",
@@ -4093,7 +4333,7 @@
     },
     {
         "name" : "minecraft:trident",
-        "id" : 546
+        "id" : 552
     },
     {
         "name" : "minecraft:trip_wire",
@@ -4109,11 +4349,11 @@
     },
     {
         "name" : "minecraft:tropical_fish_bucket",
-        "id" : 366
+        "id" : 367
     },
     {
         "name" : "minecraft:tropical_fish_spawn_egg",
-        "id" : 479
+        "id" : 480
     },
     {
         "name" : "minecraft:tuff",
@@ -4125,11 +4365,11 @@
     },
     {
         "name" : "minecraft:turtle_helmet",
-        "id" : 573
+        "id" : 579
     },
     {
         "name" : "minecraft:turtle_spawn_egg",
-        "id" : 485
+        "id" : 486
     },
     {
         "name" : "minecraft:twisting_vines",
@@ -4165,15 +4405,15 @@
     },
     {
         "name" : "minecraft:vex_spawn_egg",
-        "id" : 476
+        "id" : 477
     },
     {
         "name" : "minecraft:villager_spawn_egg",
-        "id" : 449
+        "id" : 450
     },
     {
         "name" : "minecraft:vindicator_spawn_egg",
-        "id" : 474
+        "id" : 475
     },
     {
         "name" : "minecraft:vine",
@@ -4189,11 +4429,11 @@
     },
     {
         "name" : "minecraft:wandering_trader_spawn_egg",
-        "id" : 492
+        "id" : 493
     },
     {
         "name" : "minecraft:warden_spawn_egg",
-        "id" : 632
+        "id" : 638
     },
     {
         "name" : "minecraft:warped_button",
@@ -4201,7 +4441,7 @@
     },
     {
         "name" : "minecraft:warped_door",
-        "id" : 617
+        "id" : 623
     },
     {
         "name" : "minecraft:warped_double_slab",
@@ -4221,7 +4461,11 @@
     },
     {
         "name" : "minecraft:warped_fungus_on_a_stick",
-        "id" : 618
+        "id" : 624
+    },
+    {
+        "name" : "minecraft:warped_hanging_sign",
+        "id" : -507
     },
     {
         "name" : "minecraft:warped_hyphae",
@@ -4245,7 +4489,7 @@
     },
     {
         "name" : "minecraft:warped_sign",
-        "id" : 615
+        "id" : 621
     },
     {
         "name" : "minecraft:warped_slab",
@@ -4281,7 +4525,7 @@
     },
     {
         "name" : "minecraft:water_bucket",
-        "id" : 362
+        "id" : 363
     },
     {
         "name" : "minecraft:waterlily",
@@ -4397,7 +4641,7 @@
     },
     {
         "name" : "minecraft:wheat",
-        "id" : 334
+        "id" : 335
     },
     {
         "name" : "minecraft:wheat_seeds",
@@ -4413,15 +4657,19 @@
     },
     {
         "name" : "minecraft:white_dye",
-        "id" : 410
+        "id" : 411
     },
     {
         "name" : "minecraft:white_glazed_terracotta",
         "id" : 220
     },
     {
+        "name" : "minecraft:white_wool",
+        "id" : 35
+    },
+    {
         "name" : "minecraft:witch_spawn_egg",
-        "id" : 452
+        "id" : 453
     },
     {
         "name" : "minecraft:wither_rose",
@@ -4429,11 +4677,15 @@
     },
     {
         "name" : "minecraft:wither_skeleton_spawn_egg",
-        "id" : 464
+        "id" : 465
+    },
+    {
+        "name" : "minecraft:wither_spawn_egg",
+        "id" : 508
     },
     {
         "name" : "minecraft:wolf_spawn_egg",
-        "id" : 439
+        "id" : 440
     },
     {
         "name" : "minecraft:wood",
@@ -4441,7 +4693,7 @@
     },
     {
         "name" : "minecraft:wooden_axe",
-        "id" : 311
+        "id" : 312
     },
     {
         "name" : "minecraft:wooden_button",
@@ -4449,15 +4701,15 @@
     },
     {
         "name" : "minecraft:wooden_door",
-        "id" : 359
+        "id" : 360
     },
     {
         "name" : "minecraft:wooden_hoe",
-        "id" : 329
+        "id" : 330
     },
     {
         "name" : "minecraft:wooden_pickaxe",
-        "id" : 310
+        "id" : 311
     },
     {
         "name" : "minecraft:wooden_pressure_plate",
@@ -4465,7 +4717,7 @@
     },
     {
         "name" : "minecraft:wooden_shovel",
-        "id" : 309
+        "id" : 310
     },
     {
         "name" : "minecraft:wooden_slab",
@@ -4473,19 +4725,19 @@
     },
     {
         "name" : "minecraft:wooden_sword",
-        "id" : 308
+        "id" : 309
     },
     {
         "name" : "minecraft:wool",
-        "id" : 35
+        "id" : 664
     },
     {
         "name" : "minecraft:writable_book",
-        "id" : 510
+        "id" : 516
     },
     {
         "name" : "minecraft:written_book",
-        "id" : 511
+        "id" : 517
     },
     {
         "name" : "minecraft:yellow_candle",
@@ -4497,7 +4749,7 @@
     },
     {
         "name" : "minecraft:yellow_dye",
-        "id" : 406
+        "id" : 407
     },
     {
         "name" : "minecraft:yellow_flower",
@@ -4508,23 +4760,27 @@
         "id" : 224
     },
     {
+        "name" : "minecraft:yellow_wool",
+        "id" : -558
+    },
+    {
         "name" : "minecraft:zoglin_spawn_egg",
-        "id" : 498
+        "id" : 499
     },
     {
         "name" : "minecraft:zombie_horse_spawn_egg",
-        "id" : 468
+        "id" : 469
     },
     {
         "name" : "minecraft:zombie_pigman_spawn_egg",
-        "id" : 448
+        "id" : 449
     },
     {
         "name" : "minecraft:zombie_spawn_egg",
-        "id" : 447
+        "id" : 448
     },
     {
         "name" : "minecraft:zombie_villager_spawn_egg",
-        "id" : 477
+        "id" : 478
     }
 ]

--- a/src/main/java/org/geysermc/generator/MappingsGenerator.java
+++ b/src/main/java/org/geysermc/generator/MappingsGenerator.java
@@ -281,16 +281,8 @@ public class MappingsGenerator {
                 JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:waxed_copper_block", "minecraft:waxed_copper");
                 JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:zombified_piglin_spawn_egg", "minecraft:zombie_pigman_spawn_egg");
 
-                // Item replacements
-                JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:trader_llama_spawn_egg", "minecraft:llama_spawn_egg");
-
                 // 1.19.3
-                JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:wither_spawn_egg", "minecraft:wither_skeleton_spawn_egg");
-                JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:ender_dragon_spawn_egg", "minecraft:enderman_spawn_egg");
                 JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:camel_spawn_egg", "minecraft:llama_spawn_egg");
-                JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:snow_golem_spawn_egg", "minecraft:polar_bear_spawn_egg");
-                JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:iron_golem_spawn_egg", "minecraft:wolf_spawn_egg");
-
 
             } catch (FileNotFoundException ex) {
                 ex.printStackTrace();

--- a/src/main/java/org/geysermc/generator/MappingsGenerator.java
+++ b/src/main/java/org/geysermc/generator/MappingsGenerator.java
@@ -802,7 +802,7 @@ public class MappingsGenerator {
             bedrockIdentifier = "minecraft:azalea_leaves_flowered";
         } else if (trimmedIdentifier.equals("minecraft:rooted_dirt")) {
             bedrockIdentifier = "minecraft:dirt_with_roots";
-        } else if (trimmedIdentifier.contains("cauldron")) {
+        } else if (trimmedIdentifier.contains("powder_snow_cauldron") || trimmedIdentifier.contains("water_cauldron")) {
             bedrockIdentifier = "minecraft:cauldron";
         } else if (trimmedIdentifier.equals("minecraft:waxed_copper_block")) {
             bedrockIdentifier = "minecraft:waxed_copper";


### PR DESCRIPTION
needed to fix https://github.com/GeyserMC/Geyser/issues/3675
1, Llama spawn eggs exist since 1.19.30 in both versions, so that's all neat
2. all other spawn eggs are currently 1.19.60+; compatability is done via https://github.com/GeyserMC/Geyser/pull/3688

additionally, updated the runtime_item_states.json file, got it from Geyser's core resources folder