### PR TITLE
Update mappings generator for 1.21.93

### DIFF
--- a/palettes/biome_id_map.json
+++ b/palettes/biome_id_map.json
@@ -85,5 +85,5 @@
     "the_end": 9,
     "warm_ocean": 40,
     "warped_forest": 180,
-    "pale_garden":62
+    "pale_garden": 193
 }

--- a/palettes/runtime_item_states.json
+++ b/palettes/runtime_item_states.json
@@ -13,7 +13,7 @@
     },
     {
         "name": "minecraft:acacia_chest_boat",
-        "id": 679,
+        "id": 680,
         "version": 2,
         "componentBased": false
     },
@@ -139,7 +139,7 @@
     },
     {
         "name": "minecraft:allay_spawn_egg",
-        "id": 668,
+        "id": 669,
         "version": 2,
         "componentBased": false
     },
@@ -169,7 +169,7 @@
     },
     {
         "name": "minecraft:amethyst_shard",
-        "id": 661,
+        "id": 662,
         "version": 2,
         "componentBased": false
     },
@@ -211,7 +211,7 @@
     },
     {
         "name": "minecraft:angler_pottery_sherd",
-        "id": 693,
+        "id": 694,
         "version": 2,
         "componentBased": false
     },
@@ -229,19 +229,19 @@
     },
     {
         "name": "minecraft:archer_pottery_sherd",
-        "id": 694,
+        "id": 695,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:armadillo_scute",
-        "id": 740,
+        "id": 741,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:armadillo_spawn_egg",
-        "id": 739,
+        "id": 740,
         "version": 2,
         "componentBased": false
     },
@@ -253,7 +253,7 @@
     },
     {
         "name": "minecraft:arms_up_pottery_sherd",
-        "id": 695,
+        "id": 696,
         "version": 2,
         "componentBased": false
     },
@@ -307,7 +307,7 @@
     },
     {
         "name": "minecraft:balloon",
-        "id": 635,
+        "id": 636,
         "version": 2,
         "componentBased": false
     },
@@ -331,7 +331,7 @@
     },
     {
         "name": "minecraft:bamboo_chest_raft",
-        "id": 691,
+        "id": 692,
         "version": 2,
         "componentBased": false
     },
@@ -403,7 +403,7 @@
     },
     {
         "name": "minecraft:bamboo_raft",
-        "id": 690,
+        "id": 691,
         "version": 2,
         "componentBased": false
     },
@@ -415,7 +415,7 @@
     },
     {
         "name": "minecraft:bamboo_sign",
-        "id": 689,
+        "id": 690,
         "version": 2,
         "componentBased": false
     },
@@ -457,7 +457,7 @@
     },
     {
         "name": "minecraft:banner_pattern",
-        "id": 812,
+        "id": 815,
         "version": 2,
         "componentBased": false
     },
@@ -571,7 +571,7 @@
     },
     {
         "name": "minecraft:birch_chest_boat",
-        "id": 676,
+        "id": 677,
         "version": 2,
         "componentBased": false
     },
@@ -679,7 +679,7 @@
     },
     {
         "name": "minecraft:black_bundle",
-        "id": 257,
+        "id": 273,
         "version": 1,
         "componentBased": true
     },
@@ -727,7 +727,7 @@
     },
     {
         "name": "minecraft:black_harness",
-        "id": 752,
+        "id": 753,
         "version": 2,
         "componentBased": false
     },
@@ -793,7 +793,7 @@
     },
     {
         "name": "minecraft:blade_pottery_sherd",
-        "id": 696,
+        "id": 697,
         "version": 2,
         "componentBased": false
     },
@@ -823,13 +823,13 @@
     },
     {
         "name": "minecraft:bleach",
-        "id": 633,
+        "id": 634,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:blue_bundle",
-        "id": 258,
+        "id": 266,
         "version": 1,
         "componentBased": true
     },
@@ -871,7 +871,7 @@
     },
     {
         "name": "minecraft:blue_egg",
-        "id": 749,
+        "id": 750,
         "version": 2,
         "componentBased": false
     },
@@ -883,7 +883,7 @@
     },
     {
         "name": "minecraft:blue_harness",
-        "id": 753,
+        "id": 754,
         "version": 2,
         "componentBased": false
     },
@@ -931,13 +931,13 @@
     },
     {
         "name": "minecraft:board",
-        "id": 629,
+        "id": 630,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:boat",
-        "id": 810,
+        "id": 813,
         "version": 2,
         "componentBased": false
     },
@@ -949,7 +949,7 @@
     },
     {
         "name": "minecraft:bolt_armor_trim_smithing_template",
-        "id": 735,
+        "id": 736,
         "version": 2,
         "componentBased": false
     },
@@ -1051,7 +1051,7 @@
     },
     {
         "name": "minecraft:brewer_pottery_sherd",
-        "id": 697,
+        "id": 698,
         "version": 2,
         "componentBased": false
     },
@@ -1099,7 +1099,7 @@
     },
     {
         "name": "minecraft:brown_bundle",
-        "id": 259,
+        "id": 267,
         "version": 1,
         "componentBased": true
     },
@@ -1141,7 +1141,7 @@
     },
     {
         "name": "minecraft:brown_egg",
-        "id": 750,
+        "id": 751,
         "version": 2,
         "componentBased": false
     },
@@ -1153,7 +1153,7 @@
     },
     {
         "name": "minecraft:brown_harness",
-        "id": 754,
+        "id": 755,
         "version": 2,
         "componentBased": false
     },
@@ -1201,7 +1201,7 @@
     },
     {
         "name": "minecraft:brush",
-        "id": 716,
+        "id": 717,
         "version": 2,
         "componentBased": false
     },
@@ -1249,13 +1249,13 @@
     },
     {
         "name": "minecraft:bundle",
-        "id": 260,
+        "id": 264,
         "version": 1,
         "componentBased": true
     },
     {
         "name": "minecraft:burn_pottery_sherd",
-        "id": 698,
+        "id": 699,
         "version": 2,
         "componentBased": false
     },
@@ -1297,13 +1297,13 @@
     },
     {
         "name": "minecraft:camel_spawn_egg",
-        "id": 692,
+        "id": 693,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:camera",
-        "id": 630,
+        "id": 631,
         "version": 0,
         "componentBased": false
     },
@@ -1327,7 +1327,7 @@
     },
     {
         "name": "minecraft:carpet",
-        "id": 769,
+        "id": 770,
         "version": 2,
         "componentBased": false
     },
@@ -1399,7 +1399,7 @@
     },
     {
         "name": "minecraft:chain",
-        "id": 656,
+        "id": 657,
         "version": 2,
         "componentBased": true
     },
@@ -1453,13 +1453,13 @@
     },
     {
         "name": "minecraft:chemistry_table",
-        "id": 804,
+        "id": 807,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:cherry_boat",
-        "id": 686,
+        "id": 687,
         "version": 2,
         "componentBased": false
     },
@@ -1471,7 +1471,7 @@
     },
     {
         "name": "minecraft:cherry_chest_boat",
-        "id": 687,
+        "id": 688,
         "version": 2,
         "componentBased": false
     },
@@ -1537,7 +1537,7 @@
     },
     {
         "name": "minecraft:cherry_sign",
-        "id": 688,
+        "id": 689,
         "version": 2,
         "componentBased": false
     },
@@ -1585,7 +1585,7 @@
     },
     {
         "name": "minecraft:chest_boat",
-        "id": 682,
+        "id": 683,
         "version": 2,
         "componentBased": false
     },
@@ -1759,7 +1759,7 @@
     },
     {
         "name": "minecraft:coast_armor_trim_smithing_template",
-        "id": 720,
+        "id": 721,
         "version": 2,
         "componentBased": false
     },
@@ -1855,7 +1855,7 @@
     },
     {
         "name": "minecraft:colored_torch_bp",
-        "id": 808,
+        "id": 811,
         "version": 2,
         "componentBased": false
     },
@@ -1879,7 +1879,7 @@
     },
     {
         "name": "minecraft:colored_torch_rg",
-        "id": 807,
+        "id": 810,
         "version": 2,
         "componentBased": false
     },
@@ -1915,7 +1915,7 @@
     },
     {
         "name": "minecraft:compound",
-        "id": 631,
+        "id": 632,
         "version": 2,
         "componentBased": false
     },
@@ -1927,13 +1927,13 @@
     },
     {
         "name": "minecraft:concrete",
-        "id": 795,
+        "id": 796,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:concrete_powder",
-        "id": 796,
+        "id": 797,
         "version": 2,
         "componentBased": false
     },
@@ -2035,25 +2035,25 @@
     },
     {
         "name": "minecraft:coral",
-        "id": 791,
+        "id": 792,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:coral_block",
-        "id": 773,
+        "id": 774,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:coral_fan",
-        "id": 782,
+        "id": 783,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:coral_fan_dead",
-        "id": 783,
+        "id": 784,
         "version": 2,
         "componentBased": false
     },
@@ -2119,7 +2119,7 @@
     },
     {
         "name": "minecraft:creaking_spawn_egg",
-        "id": 747,
+        "id": 748,
         "version": 2,
         "componentBased": false
     },
@@ -2149,7 +2149,7 @@
     },
     {
         "name": "minecraft:crimson_door",
-        "id": 653,
+        "id": 654,
         "version": 2,
         "componentBased": false
     },
@@ -2215,7 +2215,7 @@
     },
     {
         "name": "minecraft:crimson_sign",
-        "id": 651,
+        "id": 652,
         "version": 2,
         "componentBased": false
     },
@@ -2323,7 +2323,7 @@
     },
     {
         "name": "minecraft:cyan_bundle",
-        "id": 261,
+        "id": 265,
         "version": 1,
         "componentBased": true
     },
@@ -2371,7 +2371,7 @@
     },
     {
         "name": "minecraft:cyan_harness",
-        "id": 755,
+        "id": 756,
         "version": 2,
         "componentBased": false
     },
@@ -2419,7 +2419,7 @@
     },
     {
         "name": "minecraft:danger_pottery_sherd",
-        "id": 699,
+        "id": 700,
         "version": 2,
         "componentBased": false
     },
@@ -2437,7 +2437,7 @@
     },
     {
         "name": "minecraft:dark_oak_chest_boat",
-        "id": 680,
+        "id": 681,
         "version": 2,
         "componentBased": false
     },
@@ -2702,6 +2702,12 @@
     {
         "name": "minecraft:deadbush",
         "id": 32,
+        "version": 2,
+        "componentBased": false
+    },
+    {
+        "name": "minecraft:debug_stick",
+        "id": 626,
         "version": 2,
         "componentBased": false
     },
@@ -2977,7 +2983,7 @@
     },
     {
         "name": "minecraft:disc_fragment_5",
-        "id": 674,
+        "id": 675,
         "version": 2,
         "componentBased": false
     },
@@ -3007,31 +3013,31 @@
     },
     {
         "name": "minecraft:double_plant",
-        "id": 789,
+        "id": 790,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:double_stone_block_slab",
-        "id": 778,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:double_stone_block_slab2",
         "id": 779,
         "version": 2,
         "componentBased": false
     },
     {
-        "name": "minecraft:double_stone_block_slab3",
+        "name": "minecraft:double_stone_block_slab2",
         "id": 780,
         "version": 2,
         "componentBased": false
     },
     {
-        "name": "minecraft:double_stone_block_slab4",
+        "name": "minecraft:double_stone_block_slab3",
         "id": 781,
+        "version": 2,
+        "componentBased": false
+    },
+    {
+        "name": "minecraft:double_stone_block_slab4",
+        "id": 782,
         "version": 2,
         "componentBased": false
     },
@@ -3091,19 +3097,19 @@
     },
     {
         "name": "minecraft:dune_armor_trim_smithing_template",
-        "id": 719,
+        "id": 720,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:dye",
-        "id": 811,
+        "id": 814,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:echo_shard",
-        "id": 684,
+        "id": 685,
         "version": 2,
         "componentBased": false
     },
@@ -3901,7 +3907,7 @@
     },
     {
         "name": "minecraft:end_crystal",
-        "id": 814,
+        "id": 817,
         "version": 2,
         "componentBased": false
     },
@@ -4003,7 +4009,7 @@
     },
     {
         "name": "minecraft:explorer_pottery_sherd",
-        "id": 700,
+        "id": 701,
         "version": 2,
         "componentBased": false
     },
@@ -4069,7 +4075,7 @@
     },
     {
         "name": "minecraft:eye_armor_trim_smithing_template",
-        "id": 723,
+        "id": 724,
         "version": 2,
         "componentBased": false
     },
@@ -4087,7 +4093,7 @@
     },
     {
         "name": "minecraft:fence",
-        "id": 771,
+        "id": 772,
         "version": 2,
         "componentBased": false
     },
@@ -4201,7 +4207,7 @@
     },
     {
         "name": "minecraft:flow_armor_trim_smithing_template",
-        "id": 734,
+        "id": 735,
         "version": 2,
         "componentBased": false
     },
@@ -4213,7 +4219,7 @@
     },
     {
         "name": "minecraft:flow_pottery_sherd",
-        "id": 701,
+        "id": 702,
         "version": 2,
         "componentBased": false
     },
@@ -4261,7 +4267,7 @@
     },
     {
         "name": "minecraft:friend_pottery_sherd",
-        "id": 702,
+        "id": 703,
         "version": 2,
         "componentBased": false
     },
@@ -4273,7 +4279,7 @@
     },
     {
         "name": "minecraft:frog_spawn_egg",
-        "id": 665,
+        "id": 666,
         "version": 2,
         "componentBased": false
     },
@@ -4339,13 +4345,13 @@
     },
     {
         "name": "minecraft:glow_berries",
-        "id": 815,
+        "id": 818,
         "version": 0,
         "componentBased": false
     },
     {
         "name": "minecraft:glow_frame",
-        "id": 660,
+        "id": 661,
         "version": 2,
         "componentBased": true
     },
@@ -4369,7 +4375,7 @@
     },
     {
         "name": "minecraft:glow_stick",
-        "id": 638,
+        "id": 639,
         "version": 2,
         "componentBased": false
     },
@@ -4393,7 +4399,7 @@
     },
     {
         "name": "minecraft:goat_horn",
-        "id": 664,
+        "id": 665,
         "version": 2,
         "componentBased": false
     },
@@ -4555,7 +4561,7 @@
     },
     {
         "name": "minecraft:gray_bundle",
-        "id": 262,
+        "id": 272,
         "version": 1,
         "componentBased": true
     },
@@ -4603,7 +4609,7 @@
     },
     {
         "name": "minecraft:gray_harness",
-        "id": 756,
+        "id": 757,
         "version": 2,
         "componentBased": false
     },
@@ -4639,7 +4645,7 @@
     },
     {
         "name": "minecraft:green_bundle",
-        "id": 263,
+        "id": 269,
         "version": 1,
         "componentBased": true
     },
@@ -4687,7 +4693,7 @@
     },
     {
         "name": "minecraft:green_harness",
-        "id": 757,
+        "id": 758,
         "version": 2,
         "componentBased": false
     },
@@ -4747,7 +4753,7 @@
     },
     {
         "name": "minecraft:guster_pottery_sherd",
-        "id": 703,
+        "id": 704,
         "version": 2,
         "componentBased": false
     },
@@ -4759,7 +4765,7 @@
     },
     {
         "name": "minecraft:happy_ghast_spawn_egg",
-        "id": 751,
+        "id": 752,
         "version": 2,
         "componentBased": false
     },
@@ -4945,13 +4951,13 @@
     },
     {
         "name": "minecraft:hard_stained_glass",
-        "id": 805,
+        "id": 808,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:hard_stained_glass_pane",
-        "id": 806,
+        "id": 809,
         "version": 2,
         "componentBased": false
     },
@@ -4999,13 +5005,13 @@
     },
     {
         "name": "minecraft:heart_pottery_sherd",
-        "id": 704,
+        "id": 705,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:heartbreak_pottery_sherd",
-        "id": 705,
+        "id": 706,
         "version": 2,
         "componentBased": false
     },
@@ -5035,13 +5041,13 @@
     },
     {
         "name": "minecraft:honey_bottle",
-        "id": 627,
+        "id": 628,
         "version": 0,
         "componentBased": false
     },
     {
         "name": "minecraft:honeycomb",
-        "id": 626,
+        "id": 627,
         "version": 0,
         "componentBased": false
     },
@@ -5095,13 +5101,13 @@
     },
     {
         "name": "minecraft:host_armor_trim_smithing_template",
-        "id": 733,
+        "id": 734,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:howl_pottery_sherd",
-        "id": 706,
+        "id": 707,
         "version": 2,
         "componentBased": false
     },
@@ -5119,7 +5125,7 @@
     },
     {
         "name": "minecraft:ice_bomb",
-        "id": 632,
+        "id": 633,
         "version": 2,
         "componentBased": false
     },
@@ -5491,7 +5497,7 @@
     },
     {
         "name": "minecraft:jungle_chest_boat",
-        "id": 677,
+        "id": 678,
         "version": 2,
         "componentBased": false
     },
@@ -5713,13 +5719,13 @@
     },
     {
         "name": "minecraft:leaves",
-        "id": 785,
+        "id": 786,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:leaves2",
-        "id": 786,
+        "id": 787,
         "version": 2,
         "componentBased": false
     },
@@ -5737,7 +5743,7 @@
     },
     {
         "name": "minecraft:light_block",
-        "id": 809,
+        "id": 812,
         "version": 2,
         "componentBased": false
     },
@@ -5839,7 +5845,7 @@
     },
     {
         "name": "minecraft:light_blue_bundle",
-        "id": 264,
+        "id": 259,
         "version": 1,
         "componentBased": true
     },
@@ -5887,7 +5893,7 @@
     },
     {
         "name": "minecraft:light_blue_harness",
-        "id": 758,
+        "id": 759,
         "version": 2,
         "componentBased": false
     },
@@ -5923,7 +5929,7 @@
     },
     {
         "name": "minecraft:light_gray_bundle",
-        "id": 265,
+        "id": 271,
         "version": 1,
         "componentBased": true
     },
@@ -5965,7 +5971,7 @@
     },
     {
         "name": "minecraft:light_gray_harness",
-        "id": 759,
+        "id": 760,
         "version": 2,
         "componentBased": false
     },
@@ -6025,7 +6031,7 @@
     },
     {
         "name": "minecraft:lime_bundle",
-        "id": 266,
+        "id": 261,
         "version": 1,
         "componentBased": true
     },
@@ -6073,7 +6079,7 @@
     },
     {
         "name": "minecraft:lime_harness",
-        "id": 760,
+        "id": 761,
         "version": 2,
         "componentBased": false
     },
@@ -6169,19 +6175,19 @@
     },
     {
         "name": "minecraft:lodestone_compass",
-        "id": 639,
+        "id": 640,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:log",
-        "id": 770,
+        "id": 771,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:log2",
-        "id": 793,
+        "id": 794,
         "version": 2,
         "componentBased": false
     },
@@ -6199,7 +6205,7 @@
     },
     {
         "name": "minecraft:magenta_bundle",
-        "id": 267,
+        "id": 268,
         "version": 1,
         "componentBased": true
     },
@@ -6247,7 +6253,7 @@
     },
     {
         "name": "minecraft:magenta_harness",
-        "id": 761,
+        "id": 762,
         "version": 2,
         "componentBased": false
     },
@@ -6301,7 +6307,7 @@
     },
     {
         "name": "minecraft:mangrove_boat",
-        "id": 672,
+        "id": 673,
         "version": 2,
         "componentBased": false
     },
@@ -6313,13 +6319,13 @@
     },
     {
         "name": "minecraft:mangrove_chest_boat",
-        "id": 681,
+        "id": 682,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:mangrove_door",
-        "id": 670,
+        "id": 671,
         "version": 2,
         "componentBased": false
     },
@@ -6385,7 +6391,7 @@
     },
     {
         "name": "minecraft:mangrove_sign",
-        "id": 671,
+        "id": 672,
         "version": 2,
         "componentBased": false
     },
@@ -6433,7 +6439,7 @@
     },
     {
         "name": "minecraft:medicine",
-        "id": 636,
+        "id": 637,
         "version": 2,
         "componentBased": false
     },
@@ -6481,7 +6487,7 @@
     },
     {
         "name": "minecraft:miner_pottery_sherd",
-        "id": 707,
+        "id": 708,
         "version": 2,
         "componentBased": false
     },
@@ -6499,7 +6505,7 @@
     },
     {
         "name": "minecraft:monster_egg",
-        "id": 794,
+        "id": 795,
         "version": 2,
         "componentBased": false
     },
@@ -6583,7 +6589,7 @@
     },
     {
         "name": "minecraft:mourner_pottery_sherd",
-        "id": 708,
+        "id": 709,
         "version": 2,
         "componentBased": false
     },
@@ -6667,7 +6673,7 @@
     },
     {
         "name": "minecraft:music_disc_5",
-        "id": 673,
+        "id": 674,
         "version": 2,
         "componentBased": true
     },
@@ -6691,19 +6697,25 @@
     },
     {
         "name": "minecraft:music_disc_creator",
-        "id": 801,
+        "id": 802,
         "version": 2,
         "componentBased": true
     },
     {
         "name": "minecraft:music_disc_creator_music_box",
-        "id": 802,
+        "id": 803,
         "version": 2,
         "componentBased": true
     },
     {
         "name": "minecraft:music_disc_far",
         "id": 571,
+        "version": 2,
+        "componentBased": true
+    },
+    {
+        "name": "minecraft:music_disc_lava_chicken",
+        "id": 806,
         "version": 2,
         "componentBased": true
     },
@@ -6721,25 +6733,25 @@
     },
     {
         "name": "minecraft:music_disc_otherside",
-        "id": 663,
+        "id": 664,
         "version": 2,
         "componentBased": true
     },
     {
         "name": "minecraft:music_disc_pigstep",
-        "id": 657,
+        "id": 658,
         "version": 2,
         "componentBased": true
     },
     {
         "name": "minecraft:music_disc_precipice",
-        "id": 803,
+        "id": 804,
         "version": 2,
         "componentBased": true
     },
     {
         "name": "minecraft:music_disc_relic",
-        "id": 736,
+        "id": 737,
         "version": 2,
         "componentBased": true
     },
@@ -6752,6 +6764,12 @@
     {
         "name": "minecraft:music_disc_strad",
         "id": 575,
+        "version": 2,
+        "componentBased": true
+    },
+    {
+        "name": "minecraft:music_disc_tears",
+        "id": 805,
         "version": 2,
         "componentBased": true
     },
@@ -6835,7 +6853,7 @@
     },
     {
         "name": "minecraft:nether_sprouts",
-        "id": 658,
+        "id": 659,
         "version": 2,
         "componentBased": true
     },
@@ -6865,7 +6883,7 @@
     },
     {
         "name": "minecraft:netherite_axe",
-        "id": 643,
+        "id": 644,
         "version": 2,
         "componentBased": false
     },
@@ -6877,67 +6895,67 @@
     },
     {
         "name": "minecraft:netherite_boots",
-        "id": 649,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:netherite_chestplate",
-        "id": 647,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:netherite_helmet",
-        "id": 646,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:netherite_hoe",
-        "id": 644,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:netherite_ingot",
-        "id": 645,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:netherite_leggings",
-        "id": 648,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:netherite_pickaxe",
-        "id": 642,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:netherite_scrap",
         "id": 650,
         "version": 2,
         "componentBased": false
     },
     {
+        "name": "minecraft:netherite_chestplate",
+        "id": 648,
+        "version": 2,
+        "componentBased": false
+    },
+    {
+        "name": "minecraft:netherite_helmet",
+        "id": 647,
+        "version": 2,
+        "componentBased": false
+    },
+    {
+        "name": "minecraft:netherite_hoe",
+        "id": 645,
+        "version": 2,
+        "componentBased": false
+    },
+    {
+        "name": "minecraft:netherite_ingot",
+        "id": 646,
+        "version": 2,
+        "componentBased": false
+    },
+    {
+        "name": "minecraft:netherite_leggings",
+        "id": 649,
+        "version": 2,
+        "componentBased": false
+    },
+    {
+        "name": "minecraft:netherite_pickaxe",
+        "id": 643,
+        "version": 2,
+        "componentBased": false
+    },
+    {
+        "name": "minecraft:netherite_scrap",
+        "id": 651,
+        "version": 2,
+        "componentBased": false
+    },
+    {
         "name": "minecraft:netherite_shovel",
-        "id": 641,
+        "id": 642,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:netherite_sword",
-        "id": 640,
+        "id": 641,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:netherite_upgrade_smithing_template",
-        "id": 717,
+        "id": 718,
         "version": 2,
         "componentBased": false
     },
@@ -6991,7 +7009,7 @@
     },
     {
         "name": "minecraft:oak_chest_boat",
-        "id": 675,
+        "id": 676,
         "version": 2,
         "componentBased": false
     },
@@ -7087,13 +7105,13 @@
     },
     {
         "name": "minecraft:ominous_bottle",
-        "id": 628,
+        "id": 629,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:ominous_trial_key",
-        "id": 275,
+        "id": 276,
         "version": 1,
         "componentBased": true
     },
@@ -7105,7 +7123,7 @@
     },
     {
         "name": "minecraft:orange_bundle",
-        "id": 268,
+        "id": 258,
         "version": 1,
         "componentBased": true
     },
@@ -7153,7 +7171,7 @@
     },
     {
         "name": "minecraft:orange_harness",
-        "id": 762,
+        "id": 763,
         "version": 2,
         "componentBased": false
     },
@@ -7297,7 +7315,7 @@
     },
     {
         "name": "minecraft:pale_oak_boat",
-        "id": 744,
+        "id": 745,
         "version": 2,
         "componentBased": false
     },
@@ -7309,7 +7327,7 @@
     },
     {
         "name": "minecraft:pale_oak_chest_boat",
-        "id": 745,
+        "id": 746,
         "version": 2,
         "componentBased": false
     },
@@ -7375,7 +7393,7 @@
     },
     {
         "name": "minecraft:pale_oak_sign",
-        "id": 746,
+        "id": 747,
         "version": 2,
         "componentBased": false
     },
@@ -7507,7 +7525,7 @@
     },
     {
         "name": "minecraft:pink_bundle",
-        "id": 269,
+        "id": 257,
         "version": 1,
         "componentBased": true
     },
@@ -7555,7 +7573,7 @@
     },
     {
         "name": "minecraft:pink_harness",
-        "id": 763,
+        "id": 764,
         "version": 2,
         "componentBased": false
     },
@@ -7633,7 +7651,7 @@
     },
     {
         "name": "minecraft:planks",
-        "id": 790,
+        "id": 791,
         "version": 2,
         "componentBased": false
     },
@@ -7645,7 +7663,7 @@
     },
     {
         "name": "minecraft:plenty_pottery_sherd",
-        "id": 709,
+        "id": 710,
         "version": 2,
         "componentBased": false
     },
@@ -8017,7 +8035,7 @@
     },
     {
         "name": "minecraft:prize_pottery_sherd",
-        "id": 710,
+        "id": 711,
         "version": 2,
         "componentBased": false
     },
@@ -8065,7 +8083,7 @@
     },
     {
         "name": "minecraft:purple_bundle",
-        "id": 270,
+        "id": 263,
         "version": 1,
         "componentBased": true
     },
@@ -8113,7 +8131,7 @@
     },
     {
         "name": "minecraft:purple_harness",
-        "id": 764,
+        "id": 765,
         "version": 2,
         "componentBased": false
     },
@@ -8263,13 +8281,13 @@
     },
     {
         "name": "minecraft:raiser_armor_trim_smithing_template",
-        "id": 731,
+        "id": 732,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:rapid_fertilizer",
-        "id": 634,
+        "id": 635,
         "version": 2,
         "componentBased": false
     },
@@ -8317,13 +8335,13 @@
     },
     {
         "name": "minecraft:recovery_compass",
-        "id": 683,
+        "id": 684,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:red_bundle",
-        "id": 271,
+        "id": 262,
         "version": 1,
         "componentBased": true
     },
@@ -8365,7 +8383,7 @@
     },
     {
         "name": "minecraft:red_flower",
-        "id": 788,
+        "id": 789,
         "version": 2,
         "componentBased": false
     },
@@ -8377,7 +8395,7 @@
     },
     {
         "name": "minecraft:red_harness",
-        "id": 765,
+        "id": 766,
         "version": 2,
         "componentBased": false
     },
@@ -8563,7 +8581,7 @@
     },
     {
         "name": "minecraft:resin_brick",
-        "id": 748,
+        "id": 749,
         "version": 2,
         "componentBased": false
     },
@@ -8611,7 +8629,7 @@
     },
     {
         "name": "minecraft:rib_armor_trim_smithing_template",
-        "id": 727,
+        "id": 728,
         "version": 2,
         "componentBased": false
     },
@@ -8689,7 +8707,7 @@
     },
     {
         "name": "minecraft:sapling",
-        "id": 784,
+        "id": 785,
         "version": 2,
         "componentBased": false
     },
@@ -8701,7 +8719,7 @@
     },
     {
         "name": "minecraft:scrape_pottery_sherd",
-        "id": 711,
+        "id": 712,
         "version": 2,
         "componentBased": false
     },
@@ -8755,19 +8773,19 @@
     },
     {
         "name": "minecraft:sentry_armor_trim_smithing_template",
-        "id": 718,
+        "id": 719,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:shaper_armor_trim_smithing_template",
-        "id": 732,
+        "id": 733,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:sheaf_pottery_sherd",
-        "id": 712,
+        "id": 713,
         "version": 2,
         "componentBased": false
     },
@@ -8785,7 +8803,7 @@
     },
     {
         "name": "minecraft:shelter_pottery_sherd",
-        "id": 713,
+        "id": 714,
         "version": 2,
         "componentBased": false
     },
@@ -8815,7 +8833,7 @@
     },
     {
         "name": "minecraft:shulker_box",
-        "id": 799,
+        "id": 800,
         "version": 2,
         "componentBased": false
     },
@@ -8833,7 +8851,7 @@
     },
     {
         "name": "minecraft:silence_armor_trim_smithing_template",
-        "id": 729,
+        "id": 730,
         "version": 2,
         "componentBased": false
     },
@@ -8869,7 +8887,7 @@
     },
     {
         "name": "minecraft:skull",
-        "id": 737,
+        "id": 738,
         "version": 2,
         "componentBased": false
     },
@@ -8881,7 +8899,7 @@
     },
     {
         "name": "minecraft:skull_pottery_sherd",
-        "id": 714,
+        "id": 715,
         "version": 2,
         "componentBased": false
     },
@@ -9037,13 +9055,13 @@
     },
     {
         "name": "minecraft:snort_pottery_sherd",
-        "id": 715,
+        "id": 716,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:snout_armor_trim_smithing_template",
-        "id": 726,
+        "id": 727,
         "version": 2,
         "componentBased": false
     },
@@ -9073,7 +9091,7 @@
     },
     {
         "name": "minecraft:soul_campfire",
-        "id": 659,
+        "id": 660,
         "version": 2,
         "componentBased": true
     },
@@ -9109,13 +9127,13 @@
     },
     {
         "name": "minecraft:sparkler",
-        "id": 637,
+        "id": 638,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:spawn_egg",
-        "id": 813,
+        "id": 816,
         "version": 2,
         "componentBased": false
     },
@@ -9133,7 +9151,7 @@
     },
     {
         "name": "minecraft:spire_armor_trim_smithing_template",
-        "id": 728,
+        "id": 729,
         "version": 2,
         "componentBased": false
     },
@@ -9169,7 +9187,7 @@
     },
     {
         "name": "minecraft:spruce_chest_boat",
-        "id": 678,
+        "id": 679,
         "version": 2,
         "componentBased": false
     },
@@ -9277,7 +9295,7 @@
     },
     {
         "name": "minecraft:spyglass",
-        "id": 662,
+        "id": 663,
         "version": 2,
         "componentBased": false
     },
@@ -9289,19 +9307,19 @@
     },
     {
         "name": "minecraft:stained_glass",
-        "id": 797,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:stained_glass_pane",
         "id": 798,
         "version": 2,
         "componentBased": false
     },
     {
+        "name": "minecraft:stained_glass_pane",
+        "id": 799,
+        "version": 2,
+        "componentBased": false
+    },
+    {
         "name": "minecraft:stained_hardened_clay",
-        "id": 738,
+        "id": 739,
         "version": 2,
         "componentBased": false
     },
@@ -9349,25 +9367,25 @@
     },
     {
         "name": "minecraft:stone_block_slab",
-        "id": 774,
-        "version": 2,
-        "componentBased": false
-    },
-    {
-        "name": "minecraft:stone_block_slab2",
         "id": 775,
         "version": 2,
         "componentBased": false
     },
     {
-        "name": "minecraft:stone_block_slab3",
+        "name": "minecraft:stone_block_slab2",
         "id": 776,
         "version": 2,
         "componentBased": false
     },
     {
-        "name": "minecraft:stone_block_slab4",
+        "name": "minecraft:stone_block_slab3",
         "id": 777,
+        "version": 2,
+        "componentBased": false
+    },
+    {
+        "name": "minecraft:stone_block_slab4",
+        "id": 778,
         "version": 2,
         "componentBased": false
     },
@@ -9445,7 +9463,7 @@
     },
     {
         "name": "minecraft:stonebrick",
-        "id": 772,
+        "id": 773,
         "version": 2,
         "componentBased": false
     },
@@ -9679,13 +9697,13 @@
     },
     {
         "name": "minecraft:tadpole_bucket",
-        "id": 667,
+        "id": 668,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:tadpole_spawn_egg",
-        "id": 666,
+        "id": 667,
         "version": 2,
         "componentBased": false
     },
@@ -9703,7 +9721,7 @@
     },
     {
         "name": "minecraft:tallgrass",
-        "id": 792,
+        "id": 793,
         "version": 2,
         "componentBased": false
     },
@@ -9715,7 +9733,7 @@
     },
     {
         "name": "minecraft:tide_armor_trim_smithing_template",
-        "id": 725,
+        "id": 726,
         "version": 2,
         "componentBased": false
     },
@@ -9769,7 +9787,7 @@
     },
     {
         "name": "minecraft:trader_llama_spawn_egg",
-        "id": 685,
+        "id": 686,
         "version": 2,
         "componentBased": false
     },
@@ -9787,7 +9805,7 @@
     },
     {
         "name": "minecraft:trial_key",
-        "id": 276,
+        "id": 277,
         "version": 1,
         "componentBased": true
     },
@@ -10003,7 +10021,7 @@
     },
     {
         "name": "minecraft:vex_armor_trim_smithing_template",
-        "id": 724,
+        "id": 725,
         "version": 2,
         "componentBased": false
     },
@@ -10051,13 +10069,13 @@
     },
     {
         "name": "minecraft:ward_armor_trim_smithing_template",
-        "id": 722,
+        "id": 723,
         "version": 2,
         "componentBased": false
     },
     {
         "name": "minecraft:warden_spawn_egg",
-        "id": 669,
+        "id": 670,
         "version": 2,
         "componentBased": false
     },
@@ -10069,7 +10087,7 @@
     },
     {
         "name": "minecraft:warped_door",
-        "id": 654,
+        "id": 655,
         "version": 2,
         "componentBased": false
     },
@@ -10099,7 +10117,7 @@
     },
     {
         "name": "minecraft:warped_fungus_on_a_stick",
-        "id": 655,
+        "id": 656,
         "version": 2,
         "componentBased": true
     },
@@ -10141,7 +10159,7 @@
     },
     {
         "name": "minecraft:warped_sign",
-        "id": 652,
+        "id": 653,
         "version": 2,
         "componentBased": false
     },
@@ -10447,7 +10465,7 @@
     },
     {
         "name": "minecraft:wayfinder_armor_trim_smithing_template",
-        "id": 730,
+        "id": 731,
         "version": 2,
         "componentBased": false
     },
@@ -10543,7 +10561,7 @@
     },
     {
         "name": "minecraft:white_bundle",
-        "id": 272,
+        "id": 260,
         "version": 1,
         "componentBased": true
     },
@@ -10591,7 +10609,7 @@
     },
     {
         "name": "minecraft:white_harness",
-        "id": 766,
+        "id": 767,
         "version": 2,
         "componentBased": false
     },
@@ -10633,7 +10651,7 @@
     },
     {
         "name": "minecraft:wild_armor_trim_smithing_template",
-        "id": 721,
+        "id": 722,
         "version": 2,
         "componentBased": false
     },
@@ -10645,7 +10663,7 @@
     },
     {
         "name": "minecraft:wind_charge",
-        "id": 277,
+        "id": 275,
         "version": 1,
         "componentBased": true
     },
@@ -10681,7 +10699,7 @@
     },
     {
         "name": "minecraft:wolf_armor",
-        "id": 741,
+        "id": 742,
         "version": 2,
         "componentBased": true
     },
@@ -10693,7 +10711,7 @@
     },
     {
         "name": "minecraft:wood",
-        "id": 800,
+        "id": 801,
         "version": 2,
         "componentBased": false
     },
@@ -10741,7 +10759,7 @@
     },
     {
         "name": "minecraft:wooden_slab",
-        "id": 787,
+        "id": 788,
         "version": 2,
         "componentBased": false
     },
@@ -10753,7 +10771,7 @@
     },
     {
         "name": "minecraft:wool",
-        "id": 768,
+        "id": 769,
         "version": 2,
         "componentBased": false
     },
@@ -10771,7 +10789,7 @@
     },
     {
         "name": "minecraft:yellow_bundle",
-        "id": 273,
+        "id": 270,
         "version": 1,
         "componentBased": true
     },
@@ -10819,7 +10837,7 @@
     },
     {
         "name": "minecraft:yellow_harness",
-        "id": 767,
+        "id": 768,
         "version": 2,
         "componentBased": false
     },

--- a/src/main/java/org/geysermc/generator/MappingsGenerator.java
+++ b/src/main/java/org/geysermc/generator/MappingsGenerator.java
@@ -149,9 +149,6 @@ public class MappingsGenerator {
                 // don't exist on bedrock edition (yet)
                 JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:test_block", "minecraft:unknown");
                 JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:test_instance_block", "minecraft:unknown");
-
-                // 1.21.6
-                JAVA_TO_BEDROCK_ITEM_OVERRIDE.put("minecraft:music_disc_lava_chicken", "minecraft:music_disc_chirp");
             } catch (FileNotFoundException ex) {
                 ex.printStackTrace();
             }


### PR DESCRIPTION
Uses the correct biome ID for the pale garden biome, updates the runtime item states palette, and removes the Lava Chicken item override in the generator itself.